### PR TITLE
Create a template for GitHub issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,32 @@
+name: Bug Report
+description: A bug in the system
+title: "[Bug]: "
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: Describe the issue
+      description: What happened, and what did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce the issue?
+    validations:
+      required: true
+  - type: textarea
+    id: pr
+    attributes:
+      label: Pull request
+      description: If you can, please provide a link to the pull request that introduced the issue.
+    validations:
+      required: false
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -17,6 +17,13 @@ body:
     validations:
       required: true
   - type: textarea
+    id: cosense
+    attributes:
+      label: Cosense
+      description: Please post the Cosense URL.
+    validations:
+      required: true
+  - type: textarea
     id: pr
     attributes:
       label: Pull request

--- a/.github/ISSUE_TEMPLATE/fr.yml
+++ b/.github/ISSUE_TEMPLATE/fr.yml
@@ -17,6 +17,13 @@ body:
     validations:
       required: true
   - type: textarea
+    id: cosense
+    attributes:
+      label: Cosense
+      description: Please post the Cosense URL.
+    validations:
+      required: true
+  - type: textarea
     id: additional
     attributes:
       label: Additional context.

--- a/.github/ISSUE_TEMPLATE/fr.yml
+++ b/.github/ISSUE_TEMPLATE/fr.yml
@@ -1,0 +1,25 @@
+name: Feature Request
+description: Propose a new feature.
+title: "[FR]: "
+body:
+  - type: textarea
+    id: why
+    attributes:
+      label: Why do you need this feature?
+      description: State why this feature is needed and why it cannot be substituted by an existing feature.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Describe the proposal.
+      description: Describe the feature you would like to see implemented.
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context.
+      description: Add any other context or screenshots about the feature request here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/ref.yml
+++ b/.github/ISSUE_TEMPLATE/ref.yml
@@ -17,6 +17,13 @@ body:
     validations:
       required: true
   - type: textarea
+    id: cosense
+    attributes:
+      label: Cosense
+      description: Please post the Cosense URL.
+    validations:
+      required: true
+  - type: textarea
     id: additional
     attributes:
       label: Additional context.

--- a/.github/ISSUE_TEMPLATE/ref.yml
+++ b/.github/ISSUE_TEMPLATE/ref.yml
@@ -1,0 +1,25 @@
+name: Refactoring Proposal
+description: Propose a refactoring.
+title: "[REF]: "
+body:
+  - type: textarea
+    id: why
+    attributes:
+      label: Why do you need this refactoring?
+      description: State why this refactoring is needed and why it cannot be substituted by an existing feature.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Describe the proposal.
+      description: Describe the refactoring you would like to see implemented.
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context.
+      description: Add any other context or screenshots about the refactoring proposal here.
+    validations:
+      required: false


### PR DESCRIPTION
#7
This pull request includes the addition of three new issue templates to help streamline the process of reporting bugs, requesting features, and proposing refactoring changes. The most important changes include the creation of structured forms for each type of issue, ensuring that all necessary information is collected effectively.

New issue templates:

* [`.github/ISSUE_TEMPLATE/bug.yml`](diffhunk://#diff-45b5634e925b86895feee745ec5650893bae0d56e11b379745e506fd9a6b81bdR1-R32): Added a bug report template with fields for describing the issue, steps to reproduce, related pull requests, and additional context.
* [`.github/ISSUE_TEMPLATE/fr.yml`](diffhunk://#diff-8fdaa7cd555d3f5b3c1b3ff9a413def0174bb225ed8cc63b8576e5cf090325dfR1-R25): Added a feature request template with fields for explaining the need for the feature, describing the proposal, and providing additional context.
* [`.github/ISSUE_TEMPLATE/ref.yml`](diffhunk://#diff-ef13b23c75284f3b38f5c00ed3f4b754e107b05f38265cd086113c4e50ef18faR1-R25): Added a refactoring proposal template with fields for explaining the need for the refactoring, describing the proposal, and providing additional context.