### PR TITLE
Fr/#13/GitHub actions to accept prs only from specific branches

### DIFF
--- a/.github/workflows/check-pr-target-branch.yml
+++ b/.github/workflows/check-pr-target-branch.yml
@@ -1,0 +1,19 @@
+name: Check PR Branch
+
+on: pull_request
+
+jobs:
+  check-pr-branch:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Check PR target branch
+      run: |
+        # Check if the source branch name begins with FR, BUG, or REF
+        if [[ "${{ github.head_ref }}" =~ ^(FR|BUG|REF) ]]; then
+          # Error if target branch is not develop
+          if [[ "${{ github.base_ref }}" != "develop" ]]; then
+            echo "Error: PR from '${{ github.head_ref }}' can only target 'develop' branch."
+            exit 1
+          fi
+        fi
+        echo "PR from '${{ github.head_ref }}' targeting '${{ github.base_ref }}' is allowed."


### PR DESCRIPTION
#13 
This pull request introduces a GitHub Actions workflow to ensure that pull requests with specific branch name prefixes target the correct branch. The most important change is the addition of a new workflow file to enforce this rule.

New GitHub Actions workflow:

* [`.github/workflows/check-pr-target-branch.yml`](diffhunk://#diff-86fe1b177c59794b1b1087cffa09385a1cef373e0cff4857b13a3d4306bf7765R1-R19): Added a workflow that checks if the source branch name begins with `FR`, `BUG`, or `REF` and ensures that such branches only target the `develop` branch. If the target branch is not `develop`, the workflow will produce an error and exit.