### PR TITLE
Disable pushing if a difference is found when make fmt is executed.

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -1,0 +1,16 @@
+name: Check Format
+
+on: push
+
+jobs:
+  check-format:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install clang-format
+        run: sudo apt-get update && sudo apt-get install clang-format
+      - name: Check format
+        run: |
+          make fmt
+          git diff --exit-code

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -1,5 +1,3 @@
 #include "webserv.hpp"
 
-int main(void) {
-	std::cout << "webserv!" << std::endl;
-}
+int main(void) { std::cout << "webserv!" << std::endl; }


### PR DESCRIPTION
#15
This pull request introduces a GitHub Actions workflow to check code formatting using `clang-format`. The workflow is triggered on every push and includes steps to checkout the repository, install `clang-format`, and run the formatting check.

New GitHub Actions workflow:

* [`.github/workflows/check-format.yml`](diffhunk://#diff-935bc253c52b1f77711f590f9ff6d5c8ce79840a1595ae28d747cdee7f27f75aR1-R16): Added a workflow named "Check Format" that runs on `ubuntu-22.04`, installs `clang-format`, and checks code formatting by running `make fmt` and verifying no changes with `git diff --exit-code`.