### PR TITLE
feat: enable to run the Docker Container `webserv` in Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-LABEL org.opencontainers.image.title="Webserv"
+LABEL org.opencontainers.image.title="webserv"
 LABEL org.opencontainers.image.description="A lightweight HTTP server implementation."
 LABEL org.opencontainers.image.authors="Shotaro Mizuochi <smizuoch@student.42tokyo.jp>"
 LABEL org.opencontainers.image.source="https://github.com/tobeshota/webserv"
@@ -19,7 +19,6 @@ RUN apt-get update && apt-get install -y \
     graphviz \
     git \
     make \
-    bash \
     curl \
     lcov \
     && apt-get clean

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,12 @@
 #    By: tobeshota <tobeshota@student.42.fr>        +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/09/12 09:34:52 by tobeshota         #+#    #+#              #
-#    Updated: 2024/12/17 12:21:31 by tobeshota        ###   ########.fr        #
+#    Updated: 2025/03/13 10:53:30 by tobeshota        ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
 NAME			=	webserv
+CONTAINER		=	webserv
 CC				=	c++
 FLAGS			=	-Wall -Wextra -Werror -std=c++98 -pedantic-errors
 RM				=	rm -rf
@@ -51,6 +52,15 @@ fclean: clean
 
 re:		fclean all
 
+up:
+	docker compose up -d
+
+run: up
+	docker exec -it $(CONTAINER) /bin/bash
+
+down:
+	docker compose down
+
 fmt:
 	make fmt -C test/
 	$(if $(SRCS), clang-format --style=Google -i $(SRCS))
@@ -70,4 +80,4 @@ coverage:
 doc:
 	make doc -C docs/ -f doc.mk
 
-.PHONY:	all clean fclean re fmt debug address test doc
+.PHONY:	all clean fclean re up run down fmt debug address test coverage doc

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,7 @@
 services:
   webserv:
+    image: webserv_img
+    container_name: webserv
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
This pull request includes several changes to the Docker configuration and build process for the `webserv` project. The most important changes include modifications to the `Dockerfile`, additions to the `Makefile`, and updates to the `compose.yaml` file.

### Docker configuration updates:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L3-R3): Corrected the image title label from "Webserv" to "webserv" and removed the installation of `bash` from the list of packages. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L3-R3) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L22)

### Build process improvements:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L9-R14): Updated the timestamp of the last modification, added a new variable `CONTAINER` for the container name, and introduced new targets (`up`, `run`, `down`) to manage Docker containers. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L9-R14) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R55-R63)
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L73-R83): Added `up`, `run`, and `down` targets to the `.PHONY` list to ensure they are always executed.

### Docker Compose updates:

* [`compose.yaml`](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR3-R4): Added `image` and `container_name` fields for the `webserv` service to specify the image name and container name.