### PR TITLE
fix c++98

### DIFF
--- a/srcs/Directive.hpp
+++ b/srcs/Directive.hpp
@@ -104,7 +104,8 @@ class Directive {
   }
 
   // C++98互換の便利メソッド - 2つのパラメータ
-  const Directive *findDirective(const std::string &dir1, const std::string &dir2) const {
+  const Directive *findDirective(const std::string &dir1,
+                                 const std::string &dir2) const {
     std::vector<std::string> dirs;
     dirs.push_back(dir1);
     dirs.push_back(dir2);
@@ -112,8 +113,9 @@ class Directive {
   }
 
   // C++98互換の便利メソッド - 3つのパラメータ
-  const Directive *findDirective(const std::string &dir1, const std::string &dir2, 
-                               const std::string &dir3) const {
+  const Directive *findDirective(const std::string &dir1,
+                                 const std::string &dir2,
+                                 const std::string &dir3) const {
     std::vector<std::string> dirs;
     dirs.push_back(dir1);
     dirs.push_back(dir2);

--- a/srcs/Directive.hpp
+++ b/srcs/Directive.hpp
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <iostream>
 #include <map>
 #include <string>
@@ -95,10 +96,29 @@ class Directive {
     return NULL;
   }
 
-  // 初期化リストを使って呼び出し可能なバージョン
-  const Directive *findDirective(
-      std::initializer_list<std::string> dirNames) const {
-    return findDirective(std::vector<std::string>(dirNames));
+  // C++98互換の便利メソッド - 1つのパラメータ
+  const Directive *findDirective(const std::string &dir1) const {
+    std::vector<std::string> dirs;
+    dirs.push_back(dir1);
+    return findDirective(dirs);
+  }
+
+  // C++98互換の便利メソッド - 2つのパラメータ
+  const Directive *findDirective(const std::string &dir1, const std::string &dir2) const {
+    std::vector<std::string> dirs;
+    dirs.push_back(dir1);
+    dirs.push_back(dir2);
+    return findDirective(dirs);
+  }
+
+  // C++98互換の便利メソッド - 3つのパラメータ
+  const Directive *findDirective(const std::string &dir1, const std::string &dir2, 
+                               const std::string &dir3) const {
+    std::vector<std::string> dirs;
+    dirs.push_back(dir1);
+    dirs.push_back(dir2);
+    dirs.push_back(dir3);
+    return findDirective(dirs);
   }
 
  private:


### PR DESCRIPTION
This pull request includes updates to the `Directive` class in the `srcs/Directive.hpp` file to improve compatibility with C++98 and add convenience methods. Additionally, there is a minor formatting change.

### Compatibility and Convenience Methods:

* Added C++98 compatible convenience methods to `Directive` class for finding directives with one, two, or three parameters. This change replaces the initializer list version with methods that take individual string parameters and convert them to a vector internally.

### Formatting:

* Added a blank line after the `#pragma once` directive for improved readability.
