### PR TITLE
feat: defile `Handler` class

### DIFF
--- a/srcs/Handler.hpp
+++ b/srcs/Handler.hpp
@@ -9,7 +9,7 @@ class Handler {
   Handler* _nextHandler;
 
  public:
-  Handler() : _nextHandler(NULL) {};
+  Handler() : _nextHandler(NULL){};
   ~Handler() { ; }
   void setNextHandler(Handler* handler) { _nextHandler = handler; }
   virtual void handleRequest(HTTPResponse& httpResponse) = 0;

--- a/srcs/Handler.hpp
+++ b/srcs/Handler.hpp
@@ -9,8 +9,8 @@ class Handler {
   Handler* _nextHandler;
 
  public:
- Handler() : _nextHandler(NULL) {};
- ~Handler() { ; }
+  Handler() : _nextHandler(NULL) {};
+  ~Handler() { ; }
   void setNextHandler(Handler* handler) { _nextHandler = handler; }
   virtual void handleRequest(HTTPResponse& httpResponse) = 0;
 };

--- a/srcs/Handler.hpp
+++ b/srcs/Handler.hpp
@@ -4,17 +4,13 @@
 #include "HTTPRequest.hpp"
 #include "HTTPResponse.hpp"
 
-class Handler : public Directive, HTTPRequest, HTTPResponse {
+class Handler {
  protected:
-  Directive _conf;
-  HTTPResponse _http_response;
-  Handler* nextHandler;
+  Handler* _nextHandler;
 
  public:
-  Handler();
-  virtual ~Handler() {}
-
-  void setNextHandler(Handler* handler) { nextHandler = handler; }
-
-  virtual void handleRequest(const HTTPRequest& request) = 0;
+ Handler() : _nextHandler(NULL) {};
+ ~Handler() { ; }
+  void setNextHandler(Handler* handler) { _nextHandler = handler; }
+  virtual void handleRequest(HTTPResponse& httpResponse) = 0;
 };


### PR DESCRIPTION
This pull request includes a major refactoring of the `Handler` class in the `srcs/Handler.hpp` file. The changes simplify the class by removing inheritance and modifying its structure.

Refactoring of `Handler` class:

* Removed inheritance from `Directive`, `HTTPRequest`, and `HTTPResponse` classes.
* Removed the `_conf` and `_http_response` member variables.
* Renamed `nextHandler` to `_nextHandler` and updated its type to `Handler*`.
* Updated the `handleRequest` method to take an `HTTPResponse&` parameter instead of a `const HTTPRequest&`.