### PR TITLE
feat: define the `HTTPResponse` class

### DIFF
--- a/srcs/HTTPResponse.hpp
+++ b/srcs/HTTPResponse.hpp
@@ -1,10 +1,36 @@
 #pragma once
 
-// HTTPレスポンスの構造体が含まれる
+#include <string>
 class HTTPResponse {
- private:
-  /* data */
+ protected:
+  int _httpStatusCode;
+  std::string _httpStatusLine;
+  std::string _httpResponseHeader;
+  std::string _httpResponseBody;
+
  public:
+  // getter
+  int getHttpStatusCode() const { return _httpStatusCode; }
+  const std::string& getHttpStatusLine() const { return _httpStatusLine; }
+  const std::string& getHttpResponseHeader() const {
+    return _httpResponseHeader;
+  }
+  const std::string& getHttpResponseBody() const { return _httpResponseBody; }
+
+  // setter
+  void setHttpStatusCode(int httpStatusCode) {
+    _httpStatusCode = httpStatusCode;
+  }
+  void setHttpStatusLine(std::string httpStatusLine) {
+    _httpStatusLine = httpStatusLine;
+  }
+  void setHttpResponseHeader(std::string httpResponseHeader) {
+    _httpResponseHeader = httpResponseHeader;
+  }
+  void setHttpResponseBody(std::string httpResponseBody) {
+    _httpResponseBody = httpResponseBody;
+  }
+
   HTTPResponse(/* args */);
   ~HTTPResponse();
 };


### PR DESCRIPTION
This pull request includes significant changes to the `HTTPResponse` class in the `srcs/HTTPResponse.hpp` file. The modifications primarily focus on enhancing the encapsulation and accessibility of the HTTP response attributes by introducing getter and setter methods.

Key changes include:

* Added private member variables `_httpStatusCode`, `_httpStatusLine`, `_httpResponseHeader`, and `_httpResponseBody` to store the HTTP response details.
* Introduced getter methods for accessing the values of `_httpStatusCode`, `_httpStatusLine`, `_httpResponseHeader`, and `_httpResponseBody`.
* Introduced setter methods for modifying the values of `_httpStatusCode`, `_httpStatusLine`, `_httpResponseHeader`, and `_httpResponseBody`.
* Changed the access specifier of the member variables from `private` to `protected` to allow derived classes to access these members.