### PR TITLE
fix: add the definition of constructor and destructor

### DIFF
--- a/srcs/HTTPResponse.hpp
+++ b/srcs/HTTPResponse.hpp
@@ -31,6 +31,6 @@ class HTTPResponse {
     _httpResponseBody = httpResponseBody;
   }
 
-  HTTPResponse(/* args */);
-  ~HTTPResponse();
+  HTTPResponse() { ; }
+  ~HTTPResponse() { ; }
 };


### PR DESCRIPTION
This pull request includes a small change to the `HTTPResponse` class in `srcs/HTTPResponse.hpp`. The change involves modifying the constructor and destructor to have empty bodies instead of being undefined.

* [`srcs/HTTPResponse.hpp`](diffhunk://#diff-e67c10a68f3c350f36c1f2b37521cf55e9b158a80d0119d0cec406fb5cf8a464L34-R35): Updated the `HTTPResponse` constructor and destructor to have empty bodies.