### PR TITLE
Fr/#50/create handleerror

### DIFF
--- a/conf/webserv.conf
+++ b/conf/webserv.conf
@@ -1,7 +1,7 @@
 [localhost]
 listen = 80
 # 静的ファイルの提供元を指定
-root = "/path/to/frontend"
+root = "./html"
 
 # デフォルトで提供するファイル
 index = "index.html"

--- a/html/defaultErrorPage.html
+++ b/html/defaultErrorPage.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+        <title>Default Error Page</title>
+        <link href="main.css" rel="stylesheet" type="text/css">
+    </head>
+
+    <body>
+        <div id="app">
+            <div>Default Error Page</div>
+        </div>
+    </body>
+</html>

--- a/srcs/HandleError.cpp
+++ b/srcs/HandleError.cpp
@@ -1,0 +1,111 @@
+#include "HandleError.hpp"
+
+std::string int2str(int nb) {
+    std::stringstream ss;
+    ss << nb;
+    return ss.str();
+}
+
+std::string HandleError::generateHttpStatusLine(const int status_code) {
+  StatusCodes statusCodes;
+
+  std::string httpStatusLine = std::string(_httpRequest.getVersion()) + " ";  //  http version
+  httpStatusLine += int2str(status_code);  //  http status code
+  httpStatusLine += " " + statusCodes.getMessage(status_code) + "\n";  //  http status message
+  return httpStatusLine;
+}
+
+std::string readFile(const std::string& filePath) {
+  // ファイルを開く
+  std::ifstream file(filePath.c_str());
+
+  // ファイルが正常に開けなかった場合
+  if (!file.is_open()) {
+    return "";
+  }
+
+  // ストリームバッファを使って効率的に読み込む
+  std::stringstream buffer;
+  buffer << file.rdbuf();
+
+  // ファイルは自動的に閉じられる（RAIIパターン）
+  return buffer.str();
+}
+
+// DateのHTTPレスポンスヘッダは省略する．必要になったら設定する．
+// #include <ctime>  // 時刻の取得や操作を行うためのヘッダ。time(), gmtime(), struct tmなどの機能を提供。
+// #include <iomanip>  // 入力/出力のフォーマット設定を行うためのヘッダ。std::setfill('0')やstd::setw(2)など、表示フォーマットを制御するために使用。
+// std::string getCurrentTimeInGMTFormat() {
+//   // 現在の時刻を取得
+//   time_t rawtime;
+//   struct tm* timeinfo;
+//   time(&rawtime);
+//   timeinfo = gmtime(&rawtime);  // GMT(UTC)に変換
+
+//   // 曜日の配列
+//   const char* weekdays[] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
+//   // 月の配列
+//   const char* months[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
+//                           "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+
+//   // 出力用の文字列ストリーム
+//   std::stringstream result;
+
+//   // 現在時刻を指定の形式でストリームに追加
+//   result << weekdays[timeinfo->tm_wday] << ", " << timeinfo->tm_mday << " "
+//          << months[timeinfo->tm_mon] << " " << (1900 + timeinfo->tm_year) << " "
+//          << std::setfill('0') << std::setw(2) << timeinfo->tm_hour << ":"
+//          << std::setfill('0') << std::setw(2) << timeinfo->tm_min << ":"
+//          << std::setfill('0') << std::setw(2) << timeinfo->tm_sec << " GMT";
+
+//   // 結果を返す
+//   return result.str();
+// }
+
+std::string HandleError::generateHttpResponseHeader(
+    const std::string& httpResponseBody) {
+  std::string httpResponseHeader = "Server: webserv\n";
+  // httpResponseHeader += "Date: " + getCurrentTimeInGMTFormat() + "\n";
+  httpResponseHeader += "Content-Type: text/html\n";
+  httpResponseHeader += "Content-Length: " + int2str(httpResponseBody.size()) + "\n";
+  httpResponseHeader += "Connection: close\n";
+  return httpResponseHeader;
+}
+
+// webserv.confのディレクティブerror_page, index指定のファイル
+// error_page 404 /custom_404.html; のように設定できる．
+std::string HandleError::generateHttpResponseBody(const int status_code) {
+  std::string httpResponseBody, errorPageValue, rootValue;
+
+  const Directive *errorPageDirective = _rootDirective.findDirective(_httpRequest.getHeader("Host"), "error_page");
+  if (errorPageDirective == NULL)
+    return readFile(DEFAULT_ERROR_PAGE);
+  errorPageValue = errorPageDirective->getValue(int2str(status_code));
+
+  const Directive* hostDirective = _rootDirective.findDirective(_httpRequest.getHeader("Host"));
+  if (hostDirective != NULL) {
+    rootValue = hostDirective->getValue("root");
+  }
+
+  const std::string& errorPagePath = rootValue + errorPageValue;
+
+  httpResponseBody = readFile(errorPagePath);
+  if (httpResponseBody.empty()) {
+    httpResponseBody = readFile(DEFAULT_ERROR_PAGE);
+  }
+
+  return httpResponseBody;
+}
+
+HandleError::HandleError(Directive rootDirective, HTTPRequest httpRequest)
+    : _rootDirective(rootDirective),
+    _httpRequest(httpRequest) {}
+
+void HandleError::handleRequest(HTTPResponse& httpResponse) {
+  httpResponse.setHttpStatusLine( this->generateHttpStatusLine(httpResponse.getHttpStatusCode()));
+  httpResponse.setHttpResponseBody(this->generateHttpResponseBody(httpResponse.getHttpStatusCode()));
+  httpResponse.setHttpResponseHeader( this->generateHttpResponseHeader(httpResponse.getHttpResponseBody()));
+
+  if (_nextHandler != NULL)
+    _nextHandler->handleRequest(httpResponse);
+}

--- a/srcs/HandleError.cpp
+++ b/srcs/HandleError.cpp
@@ -1,17 +1,19 @@
 #include "HandleError.hpp"
 
 std::string int2str(int nb) {
-    std::stringstream ss;
-    ss << nb;
-    return ss.str();
+  std::stringstream ss;
+  ss << nb;
+  return ss.str();
 }
 
 std::string HandleError::generateHttpStatusLine(const int status_code) {
   StatusCodes statusCodes;
 
-  std::string httpStatusLine = std::string(_httpRequest.getVersion()) + " ";  //  http version
-  httpStatusLine += int2str(status_code);  //  http status code
-  httpStatusLine += " " + statusCodes.getMessage(status_code) + "\n";  //  http status message
+  std::string httpStatusLine =
+      std::string(_httpRequest.getVersion()) + " ";  //  http version
+  httpStatusLine += int2str(status_code);            //  http status code
+  httpStatusLine +=
+      " " + statusCodes.getMessage(status_code) + "\n";  //  http status message
   return httpStatusLine;
 }
 
@@ -33,8 +35,9 @@ std::string readFile(const std::string& filePath) {
 }
 
 // DateのHTTPレスポンスヘッダは省略する．必要になったら設定する．
-// #include <ctime>  // 時刻の取得や操作を行うためのヘッダ。time(), gmtime(), struct tmなどの機能を提供。
-// #include <iomanip>  // 入力/出力のフォーマット設定を行うためのヘッダ。std::setfill('0')やstd::setw(2)など、表示フォーマットを制御するために使用。
+// #include <ctime>  // 時刻の取得や操作を行うためのヘッダ。time(), gmtime(),
+// struct tmなどの機能を提供。 #include <iomanip>  //
+// 入力/出力のフォーマット設定を行うためのヘッダ。std::setfill('0')やstd::setw(2)など、表示フォーマットを制御するために使用。
 // std::string getCurrentTimeInGMTFormat() {
 //   // 現在の時刻を取得
 //   time_t rawtime;
@@ -53,7 +56,8 @@ std::string readFile(const std::string& filePath) {
 
 //   // 現在時刻を指定の形式でストリームに追加
 //   result << weekdays[timeinfo->tm_wday] << ", " << timeinfo->tm_mday << " "
-//          << months[timeinfo->tm_mon] << " " << (1900 + timeinfo->tm_year) << " "
+//          << months[timeinfo->tm_mon] << " " << (1900 + timeinfo->tm_year) <<
+//          " "
 //          << std::setfill('0') << std::setw(2) << timeinfo->tm_hour << ":"
 //          << std::setfill('0') << std::setw(2) << timeinfo->tm_min << ":"
 //          << std::setfill('0') << std::setw(2) << timeinfo->tm_sec << " GMT";
@@ -67,7 +71,8 @@ std::string HandleError::generateHttpResponseHeader(
   std::string httpResponseHeader = "Server: webserv\n";
   // httpResponseHeader += "Date: " + getCurrentTimeInGMTFormat() + "\n";
   httpResponseHeader += "Content-Type: text/html\n";
-  httpResponseHeader += "Content-Length: " + int2str(httpResponseBody.size()) + "\n";
+  httpResponseHeader +=
+      "Content-Length: " + int2str(httpResponseBody.size()) + "\n";
   httpResponseHeader += "Connection: close\n";
   return httpResponseHeader;
 }
@@ -77,12 +82,13 @@ std::string HandleError::generateHttpResponseHeader(
 std::string HandleError::generateHttpResponseBody(const int status_code) {
   std::string httpResponseBody, errorPageValue, rootValue;
 
-  const Directive *errorPageDirective = _rootDirective.findDirective(_httpRequest.getHeader("Host"), "error_page");
-  if (errorPageDirective == NULL)
-    return readFile(DEFAULT_ERROR_PAGE);
+  const Directive* errorPageDirective = _rootDirective.findDirective(
+      _httpRequest.getHeader("Host"), "error_page");
+  if (errorPageDirective == NULL) return readFile(DEFAULT_ERROR_PAGE);
   errorPageValue = errorPageDirective->getValue(int2str(status_code));
 
-  const Directive* hostDirective = _rootDirective.findDirective(_httpRequest.getHeader("Host"));
+  const Directive* hostDirective =
+      _rootDirective.findDirective(_httpRequest.getHeader("Host"));
   if (hostDirective != NULL) {
     rootValue = hostDirective->getValue("root");
   }
@@ -98,14 +104,15 @@ std::string HandleError::generateHttpResponseBody(const int status_code) {
 }
 
 HandleError::HandleError(Directive rootDirective, HTTPRequest httpRequest)
-    : _rootDirective(rootDirective),
-    _httpRequest(httpRequest) {}
+    : _rootDirective(rootDirective), _httpRequest(httpRequest) {}
 
 void HandleError::handleRequest(HTTPResponse& httpResponse) {
-  httpResponse.setHttpStatusLine( this->generateHttpStatusLine(httpResponse.getHttpStatusCode()));
-  httpResponse.setHttpResponseBody(this->generateHttpResponseBody(httpResponse.getHttpStatusCode()));
-  httpResponse.setHttpResponseHeader( this->generateHttpResponseHeader(httpResponse.getHttpResponseBody()));
+  httpResponse.setHttpStatusLine(
+      this->generateHttpStatusLine(httpResponse.getHttpStatusCode()));
+  httpResponse.setHttpResponseBody(
+      this->generateHttpResponseBody(httpResponse.getHttpStatusCode()));
+  httpResponse.setHttpResponseHeader(
+      this->generateHttpResponseHeader(httpResponse.getHttpResponseBody()));
 
-  if (_nextHandler != NULL)
-    _nextHandler->handleRequest(httpResponse);
+  if (_nextHandler != NULL) _nextHandler->handleRequest(httpResponse);
 }

--- a/srcs/HandleError.hpp
+++ b/srcs/HandleError.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <fstream>  // ファイル入出力を行うためのヘッダ。std::ifstreamやstd::ofstreamなどのファイル入出力ストリームを提供。
+#include <sstream>  // 文字列のストリーム操作を行うためのヘッダ。std::stringstreamを使って文字列を組み立て、最終的に出力するために使用。
+
+#include "Handler.hpp"
+#include "PrintResponse.hpp"
+#include "StatusCodes.hpp"
+#define DEFAULT_ERROR_PAGE "./html/defaultErrorPage.html"
+
+class HandleError : public Handler {
+ private:
+  Directive _rootDirective;
+  HTTPRequest _httpRequest;
+  std::string generateHttpStatusLine(const int status_code);
+  std::string generateHttpResponseHeader(const std::string& httpResponseBody);
+  std::string generateHttpResponseBody(const int status_code);
+
+ public:
+  HandleError(Directive rootDirective, HTTPRequest httpRequest);
+
+  void handleRequest(HTTPResponse& httpResponse);
+};

--- a/srcs/HandleError.hpp
+++ b/srcs/HandleError.hpp
@@ -4,7 +4,6 @@
 #include <sstream>  // 文字列のストリーム操作を行うためのヘッダ。std::stringstreamを使って文字列を組み立て、最終的に出力するために使用。
 
 #include "Handler.hpp"
-#include "PrintResponse.hpp"
 #include "StatusCodes.hpp"
 #define DEFAULT_ERROR_PAGE "./html/defaultErrorPage.html"
 

--- a/test/srcs/HandleErrorTest.cpp
+++ b/test/srcs/HandleErrorTest.cpp
@@ -1,0 +1,366 @@
+#include <gtest/gtest.h>
+#include "../../srcs/HandleError.hpp"
+#include "../../srcs/HTTPRequest.hpp"
+#include "../../srcs/HTTPResponse.hpp"
+#include "../../srcs/Directive.hpp"
+#include "../../srcs/StatusCodes.hpp"
+#include <fstream>
+#include <sstream>
+
+// テスト用のモックハンドラークラス
+class MockHandler : public Handler {
+public:
+    bool handleRequestCalled = false;
+    void handleRequest(HTTPResponse& httpResponse) override {
+        handleRequestCalled = true;
+    }
+};
+
+// テスト用のファイル作成ヘルパー関数
+void createTestFile(const std::string& path, const std::string& content) {
+    std::ofstream file(path.c_str());
+    file << content;
+    file.close();
+}
+
+class HandleErrorTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // テスト用のファイルを作成
+        createTestFile("./test_error_page.html", "<html><body>Custom Error Page</body></html>");
+        createTestFile("./html/test_root_error_page.html", "<html><body>Root Error Page</body></html>");
+    }
+
+    void TearDown() override {
+        // テストファイルの削除
+        std::remove("./test_error_page.html");
+        std::remove("./html/test_root_error_page.html");
+    }
+
+    // テスト用のリクエスト作成
+	HTTPRequest createTestRequest(const std::string& version = "HTTP/1.1", const std::string& host = "localhost") {
+        std::map<std::string, std::string> headers;
+        headers["Host"] = host;
+        return HTTPRequest("GET", "/", version, headers, "");
+    }
+
+    // テスト用のディレクティブ作成
+    Directive createRootDirective(const std::string& host, const std::string& errorPath, const std::string& rootPath) {
+        Directive rootDirective("parent");
+			Directive hostDirective(host);
+				hostDirective.addKeyValue("404", errorPath);
+				hostDirective.addKeyValue("root", rootPath);
+			rootDirective.addChild(hostDirective);
+		return rootDirective;
+    }
+};
+
+// コンストラクタのテスト
+TEST_F(HandleErrorTest, ConstructorTest) {
+    HTTPRequest request = createTestRequest();
+    Directive rootDirective;
+
+    HandleError handleError(rootDirective, request);
+    // コンストラクタが例外を投げなければ成功
+    SUCCEED();
+}
+
+// HTTPステータスラインの生成テスト
+TEST_F(HandleErrorTest, GenerateHttpStatusLineTest) {
+    HTTPRequest request = createTestRequest();
+    Directive rootDirective;
+    HandleError handleError(rootDirective, request);
+
+    HTTPResponse response;
+    response.setHttpStatusCode(404);
+    handleError.handleRequest(response);
+
+    std::string statusLine = response.getHttpStatusLine();
+    EXPECT_TRUE(statusLine.find("HTTP/1.1 404") != std::string::npos);
+    EXPECT_TRUE(statusLine.find("Not Found") != std::string::npos);
+}
+
+// HTTPレスポンスヘッダーの生成テスト
+TEST_F(HandleErrorTest, GenerateHttpResponseHeaderTest) {
+    HTTPRequest request = createTestRequest();
+    Directive rootDirective;
+    HandleError handleError(rootDirective, request);
+
+    HTTPResponse response;
+    response.setHttpStatusCode(404);
+    handleError.handleRequest(response);
+
+    std::string header = response.getHttpResponseHeader();
+    EXPECT_TRUE(header.find("Server: webserv") != std::string::npos);
+    EXPECT_TRUE(header.find("Content-Type: text/html") != std::string::npos);
+    EXPECT_TRUE(header.find("Content-Length:") != std::string::npos);
+    EXPECT_TRUE(header.find("Connection: close") != std::string::npos);
+}
+
+// デフォルトエラーページを使用するケースのテスト
+TEST_F(HandleErrorTest, DefaultErrorPageTest) {
+    HTTPRequest request = createTestRequest();
+    Directive rootDirective;
+    HandleError handleError(rootDirective, request);
+
+    HTTPResponse response;
+    response.setHttpStatusCode(999);  // 存在しないステータスコード
+    handleError.handleRequest(response);
+
+    // デフォルトのエラーページが使用されるはず
+    std::string body = response.getHttpResponseBody();
+    // ./html/defaultErrorPage.htmlを読み込む
+	std::ifstream file(DEFAULT_ERROR_PAGE);
+	std::stringstream buffer;
+	buffer << file.rdbuf();
+	file.close();
+	std::string defaultErrorPage = buffer.str();
+	EXPECT_EQ(body, defaultErrorPage);
+}
+
+// 次のハンドラーにリクエストが渡されるテスト
+TEST_F(HandleErrorTest, NextHandlerTest) {
+    HTTPRequest request = createTestRequest();
+    Directive rootDirective;
+    HandleError handleError(rootDirective, request);
+
+    // モックハンドラーを設定
+    MockHandler* mockHandler = new MockHandler();
+    handleError.setNextHandler(mockHandler);
+
+    HTTPResponse response;
+    response.setHttpStatusCode(404);
+    handleError.handleRequest(response);
+
+    // 次のハンドラーが呼び出されたか確認
+    EXPECT_TRUE(mockHandler->handleRequestCalled);
+
+    delete mockHandler;
+}
+
+// 異なるステータスコードでのテスト
+TEST_F(HandleErrorTest, DifferentStatusCodeTest) {
+    HTTPRequest request = createTestRequest();
+    Directive rootDirective;
+    HandleError handleError(rootDirective, request);
+
+    HTTPResponse response;
+    response.setHttpStatusCode(500);
+    handleError.handleRequest(response);
+
+    std::string statusLine = response.getHttpStatusLine();
+    EXPECT_TRUE(statusLine.find("HTTP/1.1 500") != std::string::npos);
+    EXPECT_TRUE(statusLine.find("Internal Server Error") != std::string::npos);
+}
+
+// error_pageディレクティブがない場合のテスト
+TEST_F(HandleErrorTest, NoErrorPageDirectiveTest) {
+    // error_pageディレクティブを持たないDirectiveを作成
+    Directive rootDirective("root");
+    Directive hostDirective("localhost");
+    rootDirective.addChild(hostDirective);
+
+    HTTPRequest request = createTestRequest();
+    HandleError handleError(rootDirective, request);
+
+    HTTPResponse response;
+    response.setHttpStatusCode(404);
+    handleError.handleRequest(response);
+
+    // デフォルトのエラーページが使用されるはず
+    std::ifstream file(DEFAULT_ERROR_PAGE);
+    std::stringstream buffer;
+    buffer << file.rdbuf();
+    file.close();
+    std::string defaultErrorPage = buffer.str();
+    EXPECT_EQ(response.getHttpResponseBody(), defaultErrorPage);
+}
+
+// 特定のステータスコードに対応するエラーページが定義されていない場合のテスト
+TEST_F(HandleErrorTest, NoMatchingStatusCodeTest) {
+    // 404以外のステータスコード（例：500）に対応するエラーページのみ定義
+    Directive rootDirective("root");
+    Directive hostDirective("localhost");
+    Directive errorPageDirective("error_page");
+    errorPageDirective.addKeyValue("500", "/500_error.html");
+    hostDirective.addChild(errorPageDirective);
+    hostDirective.addKeyValue("root", ".");
+    rootDirective.addChild(hostDirective);
+
+    HTTPRequest request = createTestRequest();
+    HandleError handleError(rootDirective, request);
+
+    HTTPResponse response;
+    response.setHttpStatusCode(404); // 定義されていないステータスコード
+    handleError.handleRequest(response);
+
+    // デフォルトのエラーページが使用されるはず
+    std::ifstream file(DEFAULT_ERROR_PAGE);
+    std::stringstream buffer;
+    buffer << file.rdbuf();
+    file.close();
+    std::string defaultErrorPage = buffer.str();
+    EXPECT_EQ(response.getHttpResponseBody(), defaultErrorPage);
+}
+
+// hostディレクティブがない場合のテスト
+TEST_F(HandleErrorTest, NoHostDirectiveTest) {
+    // 存在しないホスト名を使用
+    HTTPRequest request = createTestRequest("HTTP/1.1", "unknown-host.com");
+    Directive rootDirective("root");
+    // localhostだけ定義して、unknown-host.comは定義しない
+    Directive hostDirective("localhost");
+    rootDirective.addChild(hostDirective);
+
+    HandleError handleError(rootDirective, request);
+
+    HTTPResponse response;
+    response.setHttpStatusCode(404);
+    handleError.handleRequest(response);
+
+    // デフォルトのエラーページが使用されるはず
+    std::ifstream file(DEFAULT_ERROR_PAGE);
+    std::stringstream buffer;
+    buffer << file.rdbuf();
+    file.close();
+    std::string defaultErrorPage = buffer.str();
+    EXPECT_EQ(response.getHttpResponseBody(), defaultErrorPage);
+}
+
+// rootが設定されていない場合のテスト
+TEST_F(HandleErrorTest, NoRootValueTest) {
+    // rootキーがない設定
+    Directive rootDirective("root");
+    Directive hostDirective("localhost");
+    Directive errorPageDirective("error_page");
+    errorPageDirective.addKeyValue("404", "/test_error_page.html");
+    hostDirective.addChild(errorPageDirective);
+    // rootは設定しない
+    rootDirective.addChild(hostDirective);
+
+    HTTPRequest request = createTestRequest();
+    HandleError handleError(rootDirective, request);
+
+    HTTPResponse response;
+    response.setHttpStatusCode(404);
+    handleError.handleRequest(response);
+
+    // パスが正しくなくても、rootが空なので相対パスで見つけられるか試みる
+    // デフォルトのエラーページが使用されるはず
+    std::ifstream file(DEFAULT_ERROR_PAGE);
+    std::stringstream buffer;
+    buffer << file.rdbuf();
+    file.close();
+    std::string defaultErrorPage = buffer.str();
+    EXPECT_EQ(response.getHttpResponseBody(), defaultErrorPage);
+}
+
+// エラーページのパスが間違っている場合のテスト
+TEST_F(HandleErrorTest, InvalidErrorPagePathTest) {
+    Directive rootDirective = createRootDirective("localhost", "/non_existent_page.html", ".");
+
+    HTTPRequest request = createTestRequest();
+    HandleError handleError(rootDirective, request);
+
+    HTTPResponse response;
+    response.setHttpStatusCode(404);
+    handleError.handleRequest(response);
+
+    // 存在しないパスなのでデフォルトのエラーページが使用されるはず
+    std::ifstream file(DEFAULT_ERROR_PAGE);
+    std::stringstream buffer;
+    buffer << file.rdbuf();
+    file.close();
+    std::string defaultErrorPage = buffer.str();
+    EXPECT_EQ(response.getHttpResponseBody(), defaultErrorPage);
+}
+
+// 複数のホストと異なるステータスコードのテスト
+TEST_F(HandleErrorTest, MultipleHostsAndStatusCodesTest) {
+    // 異なるホスト用のエラーページを作成
+    createTestFile("./host1_404.html", "<html>Host1 404 Page</html>");
+    createTestFile("./host2_404.html", "<html>Host2 404 Page</html>");
+    createTestFile("./host1_500.html", "<html>Host1 500 Page</html>");
+
+    // 複数のホストとステータスコード設定を持つDirectiveを作成
+    Directive rootDirective("root");
+
+    // ホスト1の設定
+    Directive host1Directive("example.com");
+    host1Directive.addKeyValue("root", ".");
+    Directive errorPage1Directive("error_page");
+    errorPage1Directive.addKeyValue("404", "/host1_404.html");
+    errorPage1Directive.addKeyValue("500", "/host1_500.html");
+    host1Directive.addChild(errorPage1Directive);
+    rootDirective.addChild(host1Directive);
+
+    // ホスト2の設定
+    Directive host2Directive("another.com");
+    host2Directive.addKeyValue("root", ".");
+    Directive errorPage2Directive("error_page");
+    errorPage2Directive.addKeyValue("404", "/host2_404.html");
+    host2Directive.addChild(errorPage2Directive);
+    rootDirective.addChild(host2Directive);
+
+    // ホスト1の404エラーページをテスト
+    {
+        HTTPRequest request1 = createTestRequest("HTTP/1.1", "example.com");
+        HandleError handleError1(rootDirective, request1);
+        HTTPResponse response1;
+        response1.setHttpStatusCode(404);
+        handleError1.handleRequest(response1);
+        EXPECT_EQ(response1.getHttpResponseBody(), "<html>Host1 404 Page</html>");
+    }
+
+    // ホスト2の404エラーページをテスト
+    {
+        HTTPRequest request2 = createTestRequest("HTTP/1.1", "another.com");
+        HandleError handleError2(rootDirective, request2);
+        HTTPResponse response2;
+        response2.setHttpStatusCode(404);
+        handleError2.handleRequest(response2);
+        EXPECT_EQ(response2.getHttpResponseBody(), "<html>Host2 404 Page</html>");
+    }
+
+    // ホスト1の500エラーページをテスト
+    {
+        HTTPRequest request3 = createTestRequest("HTTP/1.1", "example.com");
+        HandleError handleError3(rootDirective, request3);
+        HTTPResponse response3;
+        response3.setHttpStatusCode(500);
+        handleError3.handleRequest(response3);
+        EXPECT_EQ(response3.getHttpResponseBody(), "<html>Host1 500 Page</html>");
+    }
+
+    // テスト後にファイル削除
+    std::remove("./host1_404.html");
+    std::remove("./host2_404.html");
+    std::remove("./host1_500.html");
+}
+
+// エラーページパスが絶対パスの場合のテスト
+TEST_F(HandleErrorTest, AbsolutePathErrorPageTest) {
+    std::string absolutePath = "./absolute_error_page.html";
+    createTestFile(absolutePath, "<html>Absolute Path Error Page</html>");
+
+    // 絶対パスを使用するDirectiveを作成
+    Directive rootDirective("root");
+    Directive hostDirective("localhost");
+    hostDirective.addKeyValue("root", "");  // rootは空
+    Directive errorPageDirective("error_page");
+    errorPageDirective.addKeyValue("404", absolutePath);
+    hostDirective.addChild(errorPageDirective);
+    rootDirective.addChild(hostDirective);
+
+    HTTPRequest request = createTestRequest();
+    HandleError handleError(rootDirective, request);
+
+    HTTPResponse response;
+    response.setHttpStatusCode(404);
+    handleError.handleRequest(response);
+
+    EXPECT_EQ(response.getHttpResponseBody(), "<html>Absolute Path Error Page</html>");
+
+    // テスト後にファイル削除
+    std::remove(absolutePath.c_str());
+}

--- a/test/srcs/HandleErrorTest.cpp
+++ b/test/srcs/HandleErrorTest.cpp
@@ -1,366 +1,375 @@
 #include <gtest/gtest.h>
-#include "../../srcs/HandleError.hpp"
-#include "../../srcs/HTTPRequest.hpp"
-#include "../../srcs/HTTPResponse.hpp"
-#include "../../srcs/Directive.hpp"
-#include "../../srcs/StatusCodes.hpp"
+
 #include <fstream>
 #include <sstream>
 
+#include "../../srcs/Directive.hpp"
+#include "../../srcs/HTTPRequest.hpp"
+#include "../../srcs/HTTPResponse.hpp"
+#include "../../srcs/HandleError.hpp"
+#include "../../srcs/StatusCodes.hpp"
+
 // テスト用のモックハンドラークラス
 class MockHandler : public Handler {
-public:
-    bool handleRequestCalled = false;
-    void handleRequest(HTTPResponse& httpResponse) override {
-        handleRequestCalled = true;
-    }
+ public:
+  bool handleRequestCalled = false;
+  void handleRequest(HTTPResponse& httpResponse) override {
+    handleRequestCalled = true;
+  }
 };
 
 // テスト用のファイル作成ヘルパー関数
 void createTestFile(const std::string& path, const std::string& content) {
-    std::ofstream file(path.c_str());
-    file << content;
-    file.close();
+  std::ofstream file(path.c_str());
+  file << content;
+  file.close();
 }
 
 class HandleErrorTest : public ::testing::Test {
-protected:
-    void SetUp() override {
-        // テスト用のファイルを作成
-        createTestFile("./test_error_page.html", "<html><body>Custom Error Page</body></html>");
-        createTestFile("./html/test_root_error_page.html", "<html><body>Root Error Page</body></html>");
-    }
+ protected:
+  void SetUp() override {
+    // テスト用のファイルを作成
+    createTestFile("./test_error_page.html",
+                   "<html><body>Custom Error Page</body></html>");
+    createTestFile("./html/test_root_error_page.html",
+                   "<html><body>Root Error Page</body></html>");
+  }
 
-    void TearDown() override {
-        // テストファイルの削除
-        std::remove("./test_error_page.html");
-        std::remove("./html/test_root_error_page.html");
-    }
+  void TearDown() override {
+    // テストファイルの削除
+    std::remove("./test_error_page.html");
+    std::remove("./html/test_root_error_page.html");
+  }
 
-    // テスト用のリクエスト作成
-	HTTPRequest createTestRequest(const std::string& version = "HTTP/1.1", const std::string& host = "localhost") {
-        std::map<std::string, std::string> headers;
-        headers["Host"] = host;
-        return HTTPRequest("GET", "/", version, headers, "");
-    }
+  // テスト用のリクエスト作成
+  HTTPRequest createTestRequest(const std::string& version = "HTTP/1.1",
+                                const std::string& host = "localhost") {
+    std::map<std::string, std::string> headers;
+    headers["Host"] = host;
+    return HTTPRequest("GET", "/", version, headers, "");
+  }
 
-    // テスト用のディレクティブ作成
-    Directive createRootDirective(const std::string& host, const std::string& errorPath, const std::string& rootPath) {
-        Directive rootDirective("parent");
-			Directive hostDirective(host);
-				hostDirective.addKeyValue("404", errorPath);
-				hostDirective.addKeyValue("root", rootPath);
-			rootDirective.addChild(hostDirective);
-		return rootDirective;
-    }
+  // テスト用のディレクティブ作成
+  Directive createRootDirective(const std::string& host,
+                                const std::string& errorPath,
+                                const std::string& rootPath) {
+    Directive rootDirective("parent");
+    Directive hostDirective(host);
+    hostDirective.addKeyValue("404", errorPath);
+    hostDirective.addKeyValue("root", rootPath);
+    rootDirective.addChild(hostDirective);
+    return rootDirective;
+  }
 };
 
 // コンストラクタのテスト
 TEST_F(HandleErrorTest, ConstructorTest) {
-    HTTPRequest request = createTestRequest();
-    Directive rootDirective;
+  HTTPRequest request = createTestRequest();
+  Directive rootDirective;
 
-    HandleError handleError(rootDirective, request);
-    // コンストラクタが例外を投げなければ成功
-    SUCCEED();
+  HandleError handleError(rootDirective, request);
+  // コンストラクタが例外を投げなければ成功
+  SUCCEED();
 }
 
 // HTTPステータスラインの生成テスト
 TEST_F(HandleErrorTest, GenerateHttpStatusLineTest) {
-    HTTPRequest request = createTestRequest();
-    Directive rootDirective;
-    HandleError handleError(rootDirective, request);
+  HTTPRequest request = createTestRequest();
+  Directive rootDirective;
+  HandleError handleError(rootDirective, request);
 
-    HTTPResponse response;
-    response.setHttpStatusCode(404);
-    handleError.handleRequest(response);
+  HTTPResponse response;
+  response.setHttpStatusCode(404);
+  handleError.handleRequest(response);
 
-    std::string statusLine = response.getHttpStatusLine();
-    EXPECT_TRUE(statusLine.find("HTTP/1.1 404") != std::string::npos);
-    EXPECT_TRUE(statusLine.find("Not Found") != std::string::npos);
+  std::string statusLine = response.getHttpStatusLine();
+  EXPECT_TRUE(statusLine.find("HTTP/1.1 404") != std::string::npos);
+  EXPECT_TRUE(statusLine.find("Not Found") != std::string::npos);
 }
 
 // HTTPレスポンスヘッダーの生成テスト
 TEST_F(HandleErrorTest, GenerateHttpResponseHeaderTest) {
-    HTTPRequest request = createTestRequest();
-    Directive rootDirective;
-    HandleError handleError(rootDirective, request);
+  HTTPRequest request = createTestRequest();
+  Directive rootDirective;
+  HandleError handleError(rootDirective, request);
 
-    HTTPResponse response;
-    response.setHttpStatusCode(404);
-    handleError.handleRequest(response);
+  HTTPResponse response;
+  response.setHttpStatusCode(404);
+  handleError.handleRequest(response);
 
-    std::string header = response.getHttpResponseHeader();
-    EXPECT_TRUE(header.find("Server: webserv") != std::string::npos);
-    EXPECT_TRUE(header.find("Content-Type: text/html") != std::string::npos);
-    EXPECT_TRUE(header.find("Content-Length:") != std::string::npos);
-    EXPECT_TRUE(header.find("Connection: close") != std::string::npos);
+  std::string header = response.getHttpResponseHeader();
+  EXPECT_TRUE(header.find("Server: webserv") != std::string::npos);
+  EXPECT_TRUE(header.find("Content-Type: text/html") != std::string::npos);
+  EXPECT_TRUE(header.find("Content-Length:") != std::string::npos);
+  EXPECT_TRUE(header.find("Connection: close") != std::string::npos);
 }
 
 // デフォルトエラーページを使用するケースのテスト
 TEST_F(HandleErrorTest, DefaultErrorPageTest) {
-    HTTPRequest request = createTestRequest();
-    Directive rootDirective;
-    HandleError handleError(rootDirective, request);
+  HTTPRequest request = createTestRequest();
+  Directive rootDirective;
+  HandleError handleError(rootDirective, request);
 
-    HTTPResponse response;
-    response.setHttpStatusCode(999);  // 存在しないステータスコード
-    handleError.handleRequest(response);
+  HTTPResponse response;
+  response.setHttpStatusCode(999);  // 存在しないステータスコード
+  handleError.handleRequest(response);
 
-    // デフォルトのエラーページが使用されるはず
-    std::string body = response.getHttpResponseBody();
-    // ./html/defaultErrorPage.htmlを読み込む
-	std::ifstream file(DEFAULT_ERROR_PAGE);
-	std::stringstream buffer;
-	buffer << file.rdbuf();
-	file.close();
-	std::string defaultErrorPage = buffer.str();
-	EXPECT_EQ(body, defaultErrorPage);
+  // デフォルトのエラーページが使用されるはず
+  std::string body = response.getHttpResponseBody();
+  // ./html/defaultErrorPage.htmlを読み込む
+  std::ifstream file(DEFAULT_ERROR_PAGE);
+  std::stringstream buffer;
+  buffer << file.rdbuf();
+  file.close();
+  std::string defaultErrorPage = buffer.str();
+  EXPECT_EQ(body, defaultErrorPage);
 }
 
 // 次のハンドラーにリクエストが渡されるテスト
 TEST_F(HandleErrorTest, NextHandlerTest) {
-    HTTPRequest request = createTestRequest();
-    Directive rootDirective;
-    HandleError handleError(rootDirective, request);
+  HTTPRequest request = createTestRequest();
+  Directive rootDirective;
+  HandleError handleError(rootDirective, request);
 
-    // モックハンドラーを設定
-    MockHandler* mockHandler = new MockHandler();
-    handleError.setNextHandler(mockHandler);
+  // モックハンドラーを設定
+  MockHandler* mockHandler = new MockHandler();
+  handleError.setNextHandler(mockHandler);
 
-    HTTPResponse response;
-    response.setHttpStatusCode(404);
-    handleError.handleRequest(response);
+  HTTPResponse response;
+  response.setHttpStatusCode(404);
+  handleError.handleRequest(response);
 
-    // 次のハンドラーが呼び出されたか確認
-    EXPECT_TRUE(mockHandler->handleRequestCalled);
+  // 次のハンドラーが呼び出されたか確認
+  EXPECT_TRUE(mockHandler->handleRequestCalled);
 
-    delete mockHandler;
+  delete mockHandler;
 }
 
 // 異なるステータスコードでのテスト
 TEST_F(HandleErrorTest, DifferentStatusCodeTest) {
-    HTTPRequest request = createTestRequest();
-    Directive rootDirective;
-    HandleError handleError(rootDirective, request);
+  HTTPRequest request = createTestRequest();
+  Directive rootDirective;
+  HandleError handleError(rootDirective, request);
 
-    HTTPResponse response;
-    response.setHttpStatusCode(500);
-    handleError.handleRequest(response);
+  HTTPResponse response;
+  response.setHttpStatusCode(500);
+  handleError.handleRequest(response);
 
-    std::string statusLine = response.getHttpStatusLine();
-    EXPECT_TRUE(statusLine.find("HTTP/1.1 500") != std::string::npos);
-    EXPECT_TRUE(statusLine.find("Internal Server Error") != std::string::npos);
+  std::string statusLine = response.getHttpStatusLine();
+  EXPECT_TRUE(statusLine.find("HTTP/1.1 500") != std::string::npos);
+  EXPECT_TRUE(statusLine.find("Internal Server Error") != std::string::npos);
 }
 
 // error_pageディレクティブがない場合のテスト
 TEST_F(HandleErrorTest, NoErrorPageDirectiveTest) {
-    // error_pageディレクティブを持たないDirectiveを作成
-    Directive rootDirective("root");
-    Directive hostDirective("localhost");
-    rootDirective.addChild(hostDirective);
+  // error_pageディレクティブを持たないDirectiveを作成
+  Directive rootDirective("root");
+  Directive hostDirective("localhost");
+  rootDirective.addChild(hostDirective);
 
-    HTTPRequest request = createTestRequest();
-    HandleError handleError(rootDirective, request);
+  HTTPRequest request = createTestRequest();
+  HandleError handleError(rootDirective, request);
 
-    HTTPResponse response;
-    response.setHttpStatusCode(404);
-    handleError.handleRequest(response);
+  HTTPResponse response;
+  response.setHttpStatusCode(404);
+  handleError.handleRequest(response);
 
-    // デフォルトのエラーページが使用されるはず
-    std::ifstream file(DEFAULT_ERROR_PAGE);
-    std::stringstream buffer;
-    buffer << file.rdbuf();
-    file.close();
-    std::string defaultErrorPage = buffer.str();
-    EXPECT_EQ(response.getHttpResponseBody(), defaultErrorPage);
+  // デフォルトのエラーページが使用されるはず
+  std::ifstream file(DEFAULT_ERROR_PAGE);
+  std::stringstream buffer;
+  buffer << file.rdbuf();
+  file.close();
+  std::string defaultErrorPage = buffer.str();
+  EXPECT_EQ(response.getHttpResponseBody(), defaultErrorPage);
 }
 
 // 特定のステータスコードに対応するエラーページが定義されていない場合のテスト
 TEST_F(HandleErrorTest, NoMatchingStatusCodeTest) {
-    // 404以外のステータスコード（例：500）に対応するエラーページのみ定義
-    Directive rootDirective("root");
-    Directive hostDirective("localhost");
-    Directive errorPageDirective("error_page");
-    errorPageDirective.addKeyValue("500", "/500_error.html");
-    hostDirective.addChild(errorPageDirective);
-    hostDirective.addKeyValue("root", ".");
-    rootDirective.addChild(hostDirective);
+  // 404以外のステータスコード（例：500）に対応するエラーページのみ定義
+  Directive rootDirective("root");
+  Directive hostDirective("localhost");
+  Directive errorPageDirective("error_page");
+  errorPageDirective.addKeyValue("500", "/500_error.html");
+  hostDirective.addChild(errorPageDirective);
+  hostDirective.addKeyValue("root", ".");
+  rootDirective.addChild(hostDirective);
 
-    HTTPRequest request = createTestRequest();
-    HandleError handleError(rootDirective, request);
+  HTTPRequest request = createTestRequest();
+  HandleError handleError(rootDirective, request);
 
-    HTTPResponse response;
-    response.setHttpStatusCode(404); // 定義されていないステータスコード
-    handleError.handleRequest(response);
+  HTTPResponse response;
+  response.setHttpStatusCode(404);  // 定義されていないステータスコード
+  handleError.handleRequest(response);
 
-    // デフォルトのエラーページが使用されるはず
-    std::ifstream file(DEFAULT_ERROR_PAGE);
-    std::stringstream buffer;
-    buffer << file.rdbuf();
-    file.close();
-    std::string defaultErrorPage = buffer.str();
-    EXPECT_EQ(response.getHttpResponseBody(), defaultErrorPage);
+  // デフォルトのエラーページが使用されるはず
+  std::ifstream file(DEFAULT_ERROR_PAGE);
+  std::stringstream buffer;
+  buffer << file.rdbuf();
+  file.close();
+  std::string defaultErrorPage = buffer.str();
+  EXPECT_EQ(response.getHttpResponseBody(), defaultErrorPage);
 }
 
 // hostディレクティブがない場合のテスト
 TEST_F(HandleErrorTest, NoHostDirectiveTest) {
-    // 存在しないホスト名を使用
-    HTTPRequest request = createTestRequest("HTTP/1.1", "unknown-host.com");
-    Directive rootDirective("root");
-    // localhostだけ定義して、unknown-host.comは定義しない
-    Directive hostDirective("localhost");
-    rootDirective.addChild(hostDirective);
+  // 存在しないホスト名を使用
+  HTTPRequest request = createTestRequest("HTTP/1.1", "unknown-host.com");
+  Directive rootDirective("root");
+  // localhostだけ定義して、unknown-host.comは定義しない
+  Directive hostDirective("localhost");
+  rootDirective.addChild(hostDirective);
 
-    HandleError handleError(rootDirective, request);
+  HandleError handleError(rootDirective, request);
 
-    HTTPResponse response;
-    response.setHttpStatusCode(404);
-    handleError.handleRequest(response);
+  HTTPResponse response;
+  response.setHttpStatusCode(404);
+  handleError.handleRequest(response);
 
-    // デフォルトのエラーページが使用されるはず
-    std::ifstream file(DEFAULT_ERROR_PAGE);
-    std::stringstream buffer;
-    buffer << file.rdbuf();
-    file.close();
-    std::string defaultErrorPage = buffer.str();
-    EXPECT_EQ(response.getHttpResponseBody(), defaultErrorPage);
+  // デフォルトのエラーページが使用されるはず
+  std::ifstream file(DEFAULT_ERROR_PAGE);
+  std::stringstream buffer;
+  buffer << file.rdbuf();
+  file.close();
+  std::string defaultErrorPage = buffer.str();
+  EXPECT_EQ(response.getHttpResponseBody(), defaultErrorPage);
 }
 
 // rootが設定されていない場合のテスト
 TEST_F(HandleErrorTest, NoRootValueTest) {
-    // rootキーがない設定
-    Directive rootDirective("root");
-    Directive hostDirective("localhost");
-    Directive errorPageDirective("error_page");
-    errorPageDirective.addKeyValue("404", "/test_error_page.html");
-    hostDirective.addChild(errorPageDirective);
-    // rootは設定しない
-    rootDirective.addChild(hostDirective);
+  // rootキーがない設定
+  Directive rootDirective("root");
+  Directive hostDirective("localhost");
+  Directive errorPageDirective("error_page");
+  errorPageDirective.addKeyValue("404", "/test_error_page.html");
+  hostDirective.addChild(errorPageDirective);
+  // rootは設定しない
+  rootDirective.addChild(hostDirective);
 
-    HTTPRequest request = createTestRequest();
-    HandleError handleError(rootDirective, request);
+  HTTPRequest request = createTestRequest();
+  HandleError handleError(rootDirective, request);
 
-    HTTPResponse response;
-    response.setHttpStatusCode(404);
-    handleError.handleRequest(response);
+  HTTPResponse response;
+  response.setHttpStatusCode(404);
+  handleError.handleRequest(response);
 
-    // パスが正しくなくても、rootが空なので相対パスで見つけられるか試みる
-    // デフォルトのエラーページが使用されるはず
-    std::ifstream file(DEFAULT_ERROR_PAGE);
-    std::stringstream buffer;
-    buffer << file.rdbuf();
-    file.close();
-    std::string defaultErrorPage = buffer.str();
-    EXPECT_EQ(response.getHttpResponseBody(), defaultErrorPage);
+  // パスが正しくなくても、rootが空なので相対パスで見つけられるか試みる
+  // デフォルトのエラーページが使用されるはず
+  std::ifstream file(DEFAULT_ERROR_PAGE);
+  std::stringstream buffer;
+  buffer << file.rdbuf();
+  file.close();
+  std::string defaultErrorPage = buffer.str();
+  EXPECT_EQ(response.getHttpResponseBody(), defaultErrorPage);
 }
 
 // エラーページのパスが間違っている場合のテスト
 TEST_F(HandleErrorTest, InvalidErrorPagePathTest) {
-    Directive rootDirective = createRootDirective("localhost", "/non_existent_page.html", ".");
+  Directive rootDirective =
+      createRootDirective("localhost", "/non_existent_page.html", ".");
 
-    HTTPRequest request = createTestRequest();
-    HandleError handleError(rootDirective, request);
+  HTTPRequest request = createTestRequest();
+  HandleError handleError(rootDirective, request);
 
-    HTTPResponse response;
-    response.setHttpStatusCode(404);
-    handleError.handleRequest(response);
+  HTTPResponse response;
+  response.setHttpStatusCode(404);
+  handleError.handleRequest(response);
 
-    // 存在しないパスなのでデフォルトのエラーページが使用されるはず
-    std::ifstream file(DEFAULT_ERROR_PAGE);
-    std::stringstream buffer;
-    buffer << file.rdbuf();
-    file.close();
-    std::string defaultErrorPage = buffer.str();
-    EXPECT_EQ(response.getHttpResponseBody(), defaultErrorPage);
+  // 存在しないパスなのでデフォルトのエラーページが使用されるはず
+  std::ifstream file(DEFAULT_ERROR_PAGE);
+  std::stringstream buffer;
+  buffer << file.rdbuf();
+  file.close();
+  std::string defaultErrorPage = buffer.str();
+  EXPECT_EQ(response.getHttpResponseBody(), defaultErrorPage);
 }
 
 // 複数のホストと異なるステータスコードのテスト
 TEST_F(HandleErrorTest, MultipleHostsAndStatusCodesTest) {
-    // 異なるホスト用のエラーページを作成
-    createTestFile("./host1_404.html", "<html>Host1 404 Page</html>");
-    createTestFile("./host2_404.html", "<html>Host2 404 Page</html>");
-    createTestFile("./host1_500.html", "<html>Host1 500 Page</html>");
+  // 異なるホスト用のエラーページを作成
+  createTestFile("./host1_404.html", "<html>Host1 404 Page</html>");
+  createTestFile("./host2_404.html", "<html>Host2 404 Page</html>");
+  createTestFile("./host1_500.html", "<html>Host1 500 Page</html>");
 
-    // 複数のホストとステータスコード設定を持つDirectiveを作成
-    Directive rootDirective("root");
+  // 複数のホストとステータスコード設定を持つDirectiveを作成
+  Directive rootDirective("root");
 
-    // ホスト1の設定
-    Directive host1Directive("example.com");
-    host1Directive.addKeyValue("root", ".");
-    Directive errorPage1Directive("error_page");
-    errorPage1Directive.addKeyValue("404", "/host1_404.html");
-    errorPage1Directive.addKeyValue("500", "/host1_500.html");
-    host1Directive.addChild(errorPage1Directive);
-    rootDirective.addChild(host1Directive);
+  // ホスト1の設定
+  Directive host1Directive("example.com");
+  host1Directive.addKeyValue("root", ".");
+  Directive errorPage1Directive("error_page");
+  errorPage1Directive.addKeyValue("404", "/host1_404.html");
+  errorPage1Directive.addKeyValue("500", "/host1_500.html");
+  host1Directive.addChild(errorPage1Directive);
+  rootDirective.addChild(host1Directive);
 
-    // ホスト2の設定
-    Directive host2Directive("another.com");
-    host2Directive.addKeyValue("root", ".");
-    Directive errorPage2Directive("error_page");
-    errorPage2Directive.addKeyValue("404", "/host2_404.html");
-    host2Directive.addChild(errorPage2Directive);
-    rootDirective.addChild(host2Directive);
+  // ホスト2の設定
+  Directive host2Directive("another.com");
+  host2Directive.addKeyValue("root", ".");
+  Directive errorPage2Directive("error_page");
+  errorPage2Directive.addKeyValue("404", "/host2_404.html");
+  host2Directive.addChild(errorPage2Directive);
+  rootDirective.addChild(host2Directive);
 
-    // ホスト1の404エラーページをテスト
-    {
-        HTTPRequest request1 = createTestRequest("HTTP/1.1", "example.com");
-        HandleError handleError1(rootDirective, request1);
-        HTTPResponse response1;
-        response1.setHttpStatusCode(404);
-        handleError1.handleRequest(response1);
-        EXPECT_EQ(response1.getHttpResponseBody(), "<html>Host1 404 Page</html>");
-    }
+  // ホスト1の404エラーページをテスト
+  {
+    HTTPRequest request1 = createTestRequest("HTTP/1.1", "example.com");
+    HandleError handleError1(rootDirective, request1);
+    HTTPResponse response1;
+    response1.setHttpStatusCode(404);
+    handleError1.handleRequest(response1);
+    EXPECT_EQ(response1.getHttpResponseBody(), "<html>Host1 404 Page</html>");
+  }
 
-    // ホスト2の404エラーページをテスト
-    {
-        HTTPRequest request2 = createTestRequest("HTTP/1.1", "another.com");
-        HandleError handleError2(rootDirective, request2);
-        HTTPResponse response2;
-        response2.setHttpStatusCode(404);
-        handleError2.handleRequest(response2);
-        EXPECT_EQ(response2.getHttpResponseBody(), "<html>Host2 404 Page</html>");
-    }
+  // ホスト2の404エラーページをテスト
+  {
+    HTTPRequest request2 = createTestRequest("HTTP/1.1", "another.com");
+    HandleError handleError2(rootDirective, request2);
+    HTTPResponse response2;
+    response2.setHttpStatusCode(404);
+    handleError2.handleRequest(response2);
+    EXPECT_EQ(response2.getHttpResponseBody(), "<html>Host2 404 Page</html>");
+  }
 
-    // ホスト1の500エラーページをテスト
-    {
-        HTTPRequest request3 = createTestRequest("HTTP/1.1", "example.com");
-        HandleError handleError3(rootDirective, request3);
-        HTTPResponse response3;
-        response3.setHttpStatusCode(500);
-        handleError3.handleRequest(response3);
-        EXPECT_EQ(response3.getHttpResponseBody(), "<html>Host1 500 Page</html>");
-    }
+  // ホスト1の500エラーページをテスト
+  {
+    HTTPRequest request3 = createTestRequest("HTTP/1.1", "example.com");
+    HandleError handleError3(rootDirective, request3);
+    HTTPResponse response3;
+    response3.setHttpStatusCode(500);
+    handleError3.handleRequest(response3);
+    EXPECT_EQ(response3.getHttpResponseBody(), "<html>Host1 500 Page</html>");
+  }
 
-    // テスト後にファイル削除
-    std::remove("./host1_404.html");
-    std::remove("./host2_404.html");
-    std::remove("./host1_500.html");
+  // テスト後にファイル削除
+  std::remove("./host1_404.html");
+  std::remove("./host2_404.html");
+  std::remove("./host1_500.html");
 }
 
 // エラーページパスが絶対パスの場合のテスト
 TEST_F(HandleErrorTest, AbsolutePathErrorPageTest) {
-    std::string absolutePath = "./absolute_error_page.html";
-    createTestFile(absolutePath, "<html>Absolute Path Error Page</html>");
+  std::string absolutePath = "./absolute_error_page.html";
+  createTestFile(absolutePath, "<html>Absolute Path Error Page</html>");
 
-    // 絶対パスを使用するDirectiveを作成
-    Directive rootDirective("root");
-    Directive hostDirective("localhost");
-    hostDirective.addKeyValue("root", "");  // rootは空
-    Directive errorPageDirective("error_page");
-    errorPageDirective.addKeyValue("404", absolutePath);
-    hostDirective.addChild(errorPageDirective);
-    rootDirective.addChild(hostDirective);
+  // 絶対パスを使用するDirectiveを作成
+  Directive rootDirective("root");
+  Directive hostDirective("localhost");
+  hostDirective.addKeyValue("root", "");  // rootは空
+  Directive errorPageDirective("error_page");
+  errorPageDirective.addKeyValue("404", absolutePath);
+  hostDirective.addChild(errorPageDirective);
+  rootDirective.addChild(hostDirective);
 
-    HTTPRequest request = createTestRequest();
-    HandleError handleError(rootDirective, request);
+  HTTPRequest request = createTestRequest();
+  HandleError handleError(rootDirective, request);
 
-    HTTPResponse response;
-    response.setHttpStatusCode(404);
-    handleError.handleRequest(response);
+  HTTPResponse response;
+  response.setHttpStatusCode(404);
+  handleError.handleRequest(response);
 
-    EXPECT_EQ(response.getHttpResponseBody(), "<html>Absolute Path Error Page</html>");
+  EXPECT_EQ(response.getHttpResponseBody(),
+            "<html>Absolute Path Error Page</html>");
 
-    // テスト後にファイル削除
-    std::remove(absolutePath.c_str());
+  // テスト後にファイル削除
+  std::remove(absolutePath.c_str());
 }


### PR DESCRIPTION
There is a sample file `HandleErrorSample` as follows. we can test by ...
```shell
$ cd WEBSERV_WORKING_DIRECTORY
$ touch  srcs/HandleErrorSample.cpp
$ c++ -Wall -Wextra -Werror -std=c++98 -pedantic-errors srcs/HandleErrorSample.cpp
srcs/HandleError.cpp srcs/HTTPRequestParser.cpp srcs/TOMLParser.cpp
srcs/HTTPRequest.cpp srcs/StatusCodes.cpp srcs/PrintResponse.cpp
$ ./a.out
```

```HandleErrorSample.cpp
#include <cstring>  //	"if (parser.feed(requestData, strlen(requestData)))" における strlen()
#include <iostream>

#include "Directive.hpp"
#include "HTTPRequestParser.hpp"
#include "HTTPResponse.hpp"
#include "HandleError.hpp"
#include "PrintResponse.hpp"
#include "TOMLParser.hpp"

/*
c++ -Wall -Wextra -Werror -std=c++98 -pedantic-errors srcs/HandleErrorSample.cpp
srcs/HandleError.cpp srcs/HTTPRequestParser.cpp srcs/TOMLParser.cpp
srcs/HTTPRequest.cpp srcs/StatusCodes.cpp srcs/PrintResponse.cpp ; ./a.out
*/

int main() {
  try {
    HTTPRequestParser parser;

    // クライアントからデータを受信したと仮定
    const char* requestData =
        "GET /index.html HTTP/1.1\r\n"
        "Host: localhost\r\n"
        "User-Agent: Mozilla/5.0\r\n"
        "\r\n";

    if (parser.feed(requestData, strlen(requestData))) {
      if (parser.hasError()) {
        std::cout << "解析エラー: " << parser.getErrorMessage() << std::endl;
      } else {
        ;  //	解析完了
      }
    } else {
      std::cout << "解析が未完了 - さらにデータが必要" << std::endl;
    }

    HTTPRequest httpRequest = parser.createRequest();

    TOMLParser toml_parser;
    Directive* rootDirective = toml_parser.parseFromFile("./conf/webserv.conf");

    // HTTPレスポンスオブジェクトを作成
    HTTPResponse httpResponse;
    // 404 Not Foundエラーを設定
    httpResponse.setHttpStatusCode(404);

    // HandleErrorオブジェクトを作成
    HandleError handleError(*rootDirective, httpRequest);

    // HandleErrorオブジェクトの次のハンドラをPrintResponseオブジェクトに設定
    PrintResponse printResponse;
    handleError.setNextHandler(&printResponse);

    // HandleErrorオブジェクトを実行
    handleError.handleRequest(httpResponse);
    return 0;
  } catch (const std::exception& e) {
    std::cerr << "Error: " << e.what() << std::endl;
    return 1;
  }
}

```