### PR TITLE
Fr/#65/mv handleerror generatehttpresponse

### DIFF
--- a/srcs/GenerateHTTPResponse.cpp
+++ b/srcs/GenerateHTTPResponse.cpp
@@ -145,14 +145,14 @@ std::string GenerateHTTPResponse::getPathForHttpResponseBody(
 }
 
 std::string GenerateHTTPResponse::generateHttpResponseBody(
-    const int status_code) {
+    const int status_code, bool& pageFound) {
   std::string httpResponseBody;
 
   httpResponseBody = readFile(getPathForHttpResponseBody(status_code));
   if (httpResponseBody.empty()) {
     httpResponseBody = readFile(DEFAULT_ERROR_PAGE);
+    pageFound = false;
   }
-
   return httpResponseBody;
 }
 
@@ -161,10 +161,15 @@ GenerateHTTPResponse::GenerateHTTPResponse(Directive rootDirective,
     : _rootDirective(rootDirective), _httpRequest(httpRequest) {}
 
 void GenerateHTTPResponse::handleRequest(HTTPResponse& httpResponse) {
+  bool pageFound = true;
+
+  httpResponse.setHttpResponseBody(this->generateHttpResponseBody(
+      httpResponse.getHttpStatusCode(), pageFound));
+  if (pageFound == false) {
+    httpResponse.setHttpStatusCode(404);
+  }
   httpResponse.setHttpStatusLine(
       this->generateHttpStatusLine(httpResponse.getHttpStatusCode()));
-  httpResponse.setHttpResponseBody(
-      this->generateHttpResponseBody(httpResponse.getHttpStatusCode()));
   httpResponse.setHttpResponseHeader(
       this->generateHttpResponseHeader(httpResponse.getHttpResponseBody()));
 

--- a/srcs/GenerateHTTPResponse.cpp
+++ b/srcs/GenerateHTTPResponse.cpp
@@ -1,4 +1,4 @@
-#include "HandleError.hpp"
+#include "GenerateHTTPResponse.hpp"
 
 std::string int2str(int nb) {
   std::stringstream ss;
@@ -6,7 +6,7 @@ std::string int2str(int nb) {
   return ss.str();
 }
 
-std::string HandleError::generateHttpStatusLine(const int status_code) {
+std::string GenerateHTTPResponse::generateHttpStatusLine(const int status_code) {
   StatusCodes statusCodes;
 
   std::string httpStatusLine =
@@ -66,7 +66,7 @@ std::string readFile(const std::string& filePath) {
 //   return result.str();
 // }
 
-std::string HandleError::generateHttpResponseHeader(
+std::string GenerateHTTPResponse::generateHttpResponseHeader(
     const std::string& httpResponseBody) {
   std::string httpResponseHeader = "Server: webserv\n";
   // httpResponseHeader += "Date: " + getCurrentTimeInGMTFormat() + "\n";
@@ -79,7 +79,7 @@ std::string HandleError::generateHttpResponseHeader(
 
 // webserv.confのディレクティブerror_page, index指定のファイル
 // error_page 404 /custom_404.html; のように設定できる．
-std::string HandleError::generateHttpResponseBody(const int status_code) {
+std::string GenerateHTTPResponse::generateHttpResponseBody(const int status_code) {
   std::string httpResponseBody, errorPageValue, rootValue;
 
   const Directive* errorPageDirective = _rootDirective.findDirective(
@@ -103,10 +103,10 @@ std::string HandleError::generateHttpResponseBody(const int status_code) {
   return httpResponseBody;
 }
 
-HandleError::HandleError(Directive rootDirective, HTTPRequest httpRequest)
+GenerateHTTPResponse::GenerateHTTPResponse(Directive rootDirective, HTTPRequest httpRequest)
     : _rootDirective(rootDirective), _httpRequest(httpRequest) {}
 
-void HandleError::handleRequest(HTTPResponse& httpResponse) {
+void GenerateHTTPResponse::handleRequest(HTTPResponse& httpResponse) {
   httpResponse.setHttpStatusLine(
       this->generateHttpStatusLine(httpResponse.getHttpStatusCode()));
   httpResponse.setHttpResponseBody(

--- a/srcs/GenerateHTTPResponse.hpp
+++ b/srcs/GenerateHTTPResponse.hpp
@@ -7,7 +7,7 @@
 #include "StatusCodes.hpp"
 #define DEFAULT_ERROR_PAGE "./html/defaultErrorPage.html"
 
-class HandleError : public Handler {
+class GenerateHTTPResponse : public Handler {
  private:
   Directive _rootDirective;
   HTTPRequest _httpRequest;
@@ -16,7 +16,7 @@ class HandleError : public Handler {
   std::string generateHttpResponseBody(const int status_code);
 
  public:
-  HandleError(Directive rootDirective, HTTPRequest httpRequest);
+  GenerateHTTPResponse(Directive rootDirective, HTTPRequest httpRequest);
 
   void handleRequest(HTTPResponse& httpResponse);
 };

--- a/srcs/GenerateHTTPResponse.hpp
+++ b/srcs/GenerateHTTPResponse.hpp
@@ -14,6 +14,8 @@ class GenerateHTTPResponse : public Handler {
   std::string generateHttpStatusLine(const int status_code);
   std::string generateHttpResponseHeader(const std::string& httpResponseBody);
   std::string generateHttpResponseBody(const int status_code);
+  // utils
+  std::string getPathForHttpResponseBody(const int status_code);
 
  public:
   GenerateHTTPResponse(Directive rootDirective, HTTPRequest httpRequest);

--- a/srcs/GenerateHTTPResponse.hpp
+++ b/srcs/GenerateHTTPResponse.hpp
@@ -13,7 +13,7 @@ class GenerateHTTPResponse : public Handler {
   HTTPRequest _httpRequest;
   std::string generateHttpStatusLine(const int status_code);
   std::string generateHttpResponseHeader(const std::string& httpResponseBody);
-  std::string generateHttpResponseBody(const int status_code);
+  std::string generateHttpResponseBody(const int status_code, bool& pageFound);
   // utils
   std::string getPathForHttpResponseBody(const int status_code);
 

--- a/test/srcs/GenerateHTTPResponseTest.cpp
+++ b/test/srcs/GenerateHTTPResponseTest.cpp
@@ -4,9 +4,9 @@
 #include <sstream>
 
 #include "../../srcs/Directive.hpp"
+#include "../../srcs/GenerateHTTPResponse.hpp"
 #include "../../srcs/HTTPRequest.hpp"
 #include "../../srcs/HTTPResponse.hpp"
-#include "../../srcs/GenerateHTTPResponse.hpp"
 #include "../../srcs/StatusCodes.hpp"
 
 // テスト用のモックハンドラークラス
@@ -143,21 +143,6 @@ TEST_F(GenerateHTTPResponseTest, NextHandlerTest) {
   EXPECT_TRUE(mockHandler->handleRequestCalled);
 
   delete mockHandler;
-}
-
-// 異なるステータスコードでのテスト
-TEST_F(GenerateHTTPResponseTest, DifferentStatusCodeTest) {
-  HTTPRequest request = createTestRequest();
-  Directive rootDirective;
-  GenerateHTTPResponse GenerateHTTPResponse(rootDirective, request);
-
-  HTTPResponse response;
-  response.setHttpStatusCode(500);
-  GenerateHTTPResponse.handleRequest(response);
-
-  std::string statusLine = response.getHttpStatusLine();
-  EXPECT_TRUE(statusLine.find("HTTP/1.1 500") != std::string::npos);
-  EXPECT_TRUE(statusLine.find("Internal Server Error") != std::string::npos);
 }
 
 // error_pageディレクティブがない場合のテスト

--- a/test/srcs/GenerateHTTPResponseTest.cpp
+++ b/test/srcs/GenerateHTTPResponseTest.cpp
@@ -6,7 +6,7 @@
 #include "../../srcs/Directive.hpp"
 #include "../../srcs/HTTPRequest.hpp"
 #include "../../srcs/HTTPResponse.hpp"
-#include "../../srcs/HandleError.hpp"
+#include "../../srcs/GenerateHTTPResponse.hpp"
 #include "../../srcs/StatusCodes.hpp"
 
 // テスト用のモックハンドラークラス
@@ -25,7 +25,7 @@ void createTestFile(const std::string& path, const std::string& content) {
   file.close();
 }
 
-class HandleErrorTest : public ::testing::Test {
+class GenerateHTTPResponseTest : public ::testing::Test {
  protected:
   void SetUp() override {
     // テスト用のファイルを作成
@@ -63,24 +63,24 @@ class HandleErrorTest : public ::testing::Test {
 };
 
 // コンストラクタのテスト
-TEST_F(HandleErrorTest, ConstructorTest) {
+TEST_F(GenerateHTTPResponseTest, ConstructorTest) {
   HTTPRequest request = createTestRequest();
   Directive rootDirective;
 
-  HandleError handleError(rootDirective, request);
+  GenerateHTTPResponse GenerateHTTPResponse(rootDirective, request);
   // コンストラクタが例外を投げなければ成功
   SUCCEED();
 }
 
 // HTTPステータスラインの生成テスト
-TEST_F(HandleErrorTest, GenerateHttpStatusLineTest) {
+TEST_F(GenerateHTTPResponseTest, GenerateHttpStatusLineTest) {
   HTTPRequest request = createTestRequest();
   Directive rootDirective;
-  HandleError handleError(rootDirective, request);
+  GenerateHTTPResponse GenerateHTTPResponse(rootDirective, request);
 
   HTTPResponse response;
   response.setHttpStatusCode(404);
-  handleError.handleRequest(response);
+  GenerateHTTPResponse.handleRequest(response);
 
   std::string statusLine = response.getHttpStatusLine();
   EXPECT_TRUE(statusLine.find("HTTP/1.1 404") != std::string::npos);
@@ -88,14 +88,14 @@ TEST_F(HandleErrorTest, GenerateHttpStatusLineTest) {
 }
 
 // HTTPレスポンスヘッダーの生成テスト
-TEST_F(HandleErrorTest, GenerateHttpResponseHeaderTest) {
+TEST_F(GenerateHTTPResponseTest, GenerateHttpResponseHeaderTest) {
   HTTPRequest request = createTestRequest();
   Directive rootDirective;
-  HandleError handleError(rootDirective, request);
+  GenerateHTTPResponse GenerateHTTPResponse(rootDirective, request);
 
   HTTPResponse response;
   response.setHttpStatusCode(404);
-  handleError.handleRequest(response);
+  GenerateHTTPResponse.handleRequest(response);
 
   std::string header = response.getHttpResponseHeader();
   EXPECT_TRUE(header.find("Server: webserv") != std::string::npos);
@@ -105,14 +105,14 @@ TEST_F(HandleErrorTest, GenerateHttpResponseHeaderTest) {
 }
 
 // デフォルトエラーページを使用するケースのテスト
-TEST_F(HandleErrorTest, DefaultErrorPageTest) {
+TEST_F(GenerateHTTPResponseTest, DefaultErrorPageTest) {
   HTTPRequest request = createTestRequest();
   Directive rootDirective;
-  HandleError handleError(rootDirective, request);
+  GenerateHTTPResponse GenerateHTTPResponse(rootDirective, request);
 
   HTTPResponse response;
   response.setHttpStatusCode(999);  // 存在しないステータスコード
-  handleError.handleRequest(response);
+  GenerateHTTPResponse.handleRequest(response);
 
   // デフォルトのエラーページが使用されるはず
   std::string body = response.getHttpResponseBody();
@@ -126,18 +126,18 @@ TEST_F(HandleErrorTest, DefaultErrorPageTest) {
 }
 
 // 次のハンドラーにリクエストが渡されるテスト
-TEST_F(HandleErrorTest, NextHandlerTest) {
+TEST_F(GenerateHTTPResponseTest, NextHandlerTest) {
   HTTPRequest request = createTestRequest();
   Directive rootDirective;
-  HandleError handleError(rootDirective, request);
+  GenerateHTTPResponse GenerateHTTPResponse(rootDirective, request);
 
   // モックハンドラーを設定
   MockHandler* mockHandler = new MockHandler();
-  handleError.setNextHandler(mockHandler);
+  GenerateHTTPResponse.setNextHandler(mockHandler);
 
   HTTPResponse response;
   response.setHttpStatusCode(404);
-  handleError.handleRequest(response);
+  GenerateHTTPResponse.handleRequest(response);
 
   // 次のハンドラーが呼び出されたか確認
   EXPECT_TRUE(mockHandler->handleRequestCalled);
@@ -146,14 +146,14 @@ TEST_F(HandleErrorTest, NextHandlerTest) {
 }
 
 // 異なるステータスコードでのテスト
-TEST_F(HandleErrorTest, DifferentStatusCodeTest) {
+TEST_F(GenerateHTTPResponseTest, DifferentStatusCodeTest) {
   HTTPRequest request = createTestRequest();
   Directive rootDirective;
-  HandleError handleError(rootDirective, request);
+  GenerateHTTPResponse GenerateHTTPResponse(rootDirective, request);
 
   HTTPResponse response;
   response.setHttpStatusCode(500);
-  handleError.handleRequest(response);
+  GenerateHTTPResponse.handleRequest(response);
 
   std::string statusLine = response.getHttpStatusLine();
   EXPECT_TRUE(statusLine.find("HTTP/1.1 500") != std::string::npos);
@@ -161,18 +161,18 @@ TEST_F(HandleErrorTest, DifferentStatusCodeTest) {
 }
 
 // error_pageディレクティブがない場合のテスト
-TEST_F(HandleErrorTest, NoErrorPageDirectiveTest) {
+TEST_F(GenerateHTTPResponseTest, NoErrorPageDirectiveTest) {
   // error_pageディレクティブを持たないDirectiveを作成
   Directive rootDirective("root");
   Directive hostDirective("localhost");
   rootDirective.addChild(hostDirective);
 
   HTTPRequest request = createTestRequest();
-  HandleError handleError(rootDirective, request);
+  GenerateHTTPResponse GenerateHTTPResponse(rootDirective, request);
 
   HTTPResponse response;
   response.setHttpStatusCode(404);
-  handleError.handleRequest(response);
+  GenerateHTTPResponse.handleRequest(response);
 
   // デフォルトのエラーページが使用されるはず
   std::ifstream file(DEFAULT_ERROR_PAGE);
@@ -184,7 +184,7 @@ TEST_F(HandleErrorTest, NoErrorPageDirectiveTest) {
 }
 
 // 特定のステータスコードに対応するエラーページが定義されていない場合のテスト
-TEST_F(HandleErrorTest, NoMatchingStatusCodeTest) {
+TEST_F(GenerateHTTPResponseTest, NoMatchingStatusCodeTest) {
   // 404以外のステータスコード（例：500）に対応するエラーページのみ定義
   Directive rootDirective("root");
   Directive hostDirective("localhost");
@@ -195,11 +195,11 @@ TEST_F(HandleErrorTest, NoMatchingStatusCodeTest) {
   rootDirective.addChild(hostDirective);
 
   HTTPRequest request = createTestRequest();
-  HandleError handleError(rootDirective, request);
+  GenerateHTTPResponse GenerateHTTPResponse(rootDirective, request);
 
   HTTPResponse response;
   response.setHttpStatusCode(404);  // 定義されていないステータスコード
-  handleError.handleRequest(response);
+  GenerateHTTPResponse.handleRequest(response);
 
   // デフォルトのエラーページが使用されるはず
   std::ifstream file(DEFAULT_ERROR_PAGE);
@@ -211,7 +211,7 @@ TEST_F(HandleErrorTest, NoMatchingStatusCodeTest) {
 }
 
 // hostディレクティブがない場合のテスト
-TEST_F(HandleErrorTest, NoHostDirectiveTest) {
+TEST_F(GenerateHTTPResponseTest, NoHostDirectiveTest) {
   // 存在しないホスト名を使用
   HTTPRequest request = createTestRequest("HTTP/1.1", "unknown-host.com");
   Directive rootDirective("root");
@@ -219,11 +219,11 @@ TEST_F(HandleErrorTest, NoHostDirectiveTest) {
   Directive hostDirective("localhost");
   rootDirective.addChild(hostDirective);
 
-  HandleError handleError(rootDirective, request);
+  GenerateHTTPResponse GenerateHTTPResponse(rootDirective, request);
 
   HTTPResponse response;
   response.setHttpStatusCode(404);
-  handleError.handleRequest(response);
+  GenerateHTTPResponse.handleRequest(response);
 
   // デフォルトのエラーページが使用されるはず
   std::ifstream file(DEFAULT_ERROR_PAGE);
@@ -235,7 +235,7 @@ TEST_F(HandleErrorTest, NoHostDirectiveTest) {
 }
 
 // rootが設定されていない場合のテスト
-TEST_F(HandleErrorTest, NoRootValueTest) {
+TEST_F(GenerateHTTPResponseTest, NoRootValueTest) {
   // rootキーがない設定
   Directive rootDirective("root");
   Directive hostDirective("localhost");
@@ -246,11 +246,11 @@ TEST_F(HandleErrorTest, NoRootValueTest) {
   rootDirective.addChild(hostDirective);
 
   HTTPRequest request = createTestRequest();
-  HandleError handleError(rootDirective, request);
+  GenerateHTTPResponse GenerateHTTPResponse(rootDirective, request);
 
   HTTPResponse response;
   response.setHttpStatusCode(404);
-  handleError.handleRequest(response);
+  GenerateHTTPResponse.handleRequest(response);
 
   // パスが正しくなくても、rootが空なので相対パスで見つけられるか試みる
   // デフォルトのエラーページが使用されるはず
@@ -263,16 +263,16 @@ TEST_F(HandleErrorTest, NoRootValueTest) {
 }
 
 // エラーページのパスが間違っている場合のテスト
-TEST_F(HandleErrorTest, InvalidErrorPagePathTest) {
+TEST_F(GenerateHTTPResponseTest, InvalidErrorPagePathTest) {
   Directive rootDirective =
       createRootDirective("localhost", "/non_existent_page.html", ".");
 
   HTTPRequest request = createTestRequest();
-  HandleError handleError(rootDirective, request);
+  GenerateHTTPResponse GenerateHTTPResponse(rootDirective, request);
 
   HTTPResponse response;
   response.setHttpStatusCode(404);
-  handleError.handleRequest(response);
+  GenerateHTTPResponse.handleRequest(response);
 
   // 存在しないパスなのでデフォルトのエラーページが使用されるはず
   std::ifstream file(DEFAULT_ERROR_PAGE);
@@ -284,7 +284,7 @@ TEST_F(HandleErrorTest, InvalidErrorPagePathTest) {
 }
 
 // 複数のホストと異なるステータスコードのテスト
-TEST_F(HandleErrorTest, MultipleHostsAndStatusCodesTest) {
+TEST_F(GenerateHTTPResponseTest, MultipleHostsAndStatusCodesTest) {
   // 異なるホスト用のエラーページを作成
   createTestFile("./host1_404.html", "<html>Host1 404 Page</html>");
   createTestFile("./host2_404.html", "<html>Host2 404 Page</html>");
@@ -313,30 +313,30 @@ TEST_F(HandleErrorTest, MultipleHostsAndStatusCodesTest) {
   // ホスト1の404エラーページをテスト
   {
     HTTPRequest request1 = createTestRequest("HTTP/1.1", "example.com");
-    HandleError handleError1(rootDirective, request1);
+    GenerateHTTPResponse GenerateHTTPResponse1(rootDirective, request1);
     HTTPResponse response1;
     response1.setHttpStatusCode(404);
-    handleError1.handleRequest(response1);
+    GenerateHTTPResponse1.handleRequest(response1);
     EXPECT_EQ(response1.getHttpResponseBody(), "<html>Host1 404 Page</html>");
   }
 
   // ホスト2の404エラーページをテスト
   {
     HTTPRequest request2 = createTestRequest("HTTP/1.1", "another.com");
-    HandleError handleError2(rootDirective, request2);
+    GenerateHTTPResponse GenerateHTTPResponse2(rootDirective, request2);
     HTTPResponse response2;
     response2.setHttpStatusCode(404);
-    handleError2.handleRequest(response2);
+    GenerateHTTPResponse2.handleRequest(response2);
     EXPECT_EQ(response2.getHttpResponseBody(), "<html>Host2 404 Page</html>");
   }
 
   // ホスト1の500エラーページをテスト
   {
     HTTPRequest request3 = createTestRequest("HTTP/1.1", "example.com");
-    HandleError handleError3(rootDirective, request3);
+    GenerateHTTPResponse GenerateHTTPResponse3(rootDirective, request3);
     HTTPResponse response3;
     response3.setHttpStatusCode(500);
-    handleError3.handleRequest(response3);
+    GenerateHTTPResponse3.handleRequest(response3);
     EXPECT_EQ(response3.getHttpResponseBody(), "<html>Host1 500 Page</html>");
   }
 
@@ -347,7 +347,7 @@ TEST_F(HandleErrorTest, MultipleHostsAndStatusCodesTest) {
 }
 
 // エラーページパスが絶対パスの場合のテスト
-TEST_F(HandleErrorTest, AbsolutePathErrorPageTest) {
+TEST_F(GenerateHTTPResponseTest, AbsolutePathErrorPageTest) {
   std::string absolutePath = "./absolute_error_page.html";
   createTestFile(absolutePath, "<html>Absolute Path Error Page</html>");
 
@@ -361,11 +361,11 @@ TEST_F(HandleErrorTest, AbsolutePathErrorPageTest) {
   rootDirective.addChild(hostDirective);
 
   HTTPRequest request = createTestRequest();
-  HandleError handleError(rootDirective, request);
+  GenerateHTTPResponse GenerateHTTPResponse(rootDirective, request);
 
   HTTPResponse response;
   response.setHttpStatusCode(404);
-  handleError.handleRequest(response);
+  GenerateHTTPResponse.handleRequest(response);
 
   EXPECT_EQ(response.getHttpResponseBody(),
             "<html>Absolute Path Error Page</html>");

--- a/test/srcs/HTTPRequestParserTest.cpp
+++ b/test/srcs/HTTPRequestParserTest.cpp
@@ -170,8 +170,3 @@ TEST_F(HTTPRequestParserTest, HeaderContinuationLine) {
   EXPECT_EQ(result.getHeader("User-Agent"),
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64)");
 }
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}


### PR DESCRIPTION
You can check the feature of `GenerateHTTPResponse` by ...
```shell
$ cd WEBSERV_WORKING_DIRECTORY
$ touch srcs/GenerateHTTPResponseSample.cpp
$ # add srcs/GenerateHTTPResponseSample.cpp. This file will be described later.
$ c++ -Wall -Wextra -Werror -std=c++98 -pedantic-errors srcs/GenerateHTTPResponseSample.cpp srcs/GenerateHTTPResponse.cpp srcs/HTTPRequestParser.cpp srcs/TOMLParser.cpp srcs/HTTPRequest.cpp srcs/StatusCodes.cpp srcs/PrintResponse.cpp
$ ./a.out
```

↓srcs/GenerateHTTPResponseSample.cpp
```.cpp
#include <cstring>  //	"if (parser.feed(requestData, strlen(requestData)))" における strlen() #include <iostream>

#include "Directive.hpp"
#include "GenerateHTTPResponse.hpp"
#include "HTTPRequestParser.hpp"
#include "HTTPResponse.hpp"
#include "PrintResponse.hpp"
#include "TOMLParser.hpp"

/*
c++ -Wall -Wextra -Werror -std=c++98 -pedantic-errors srcs/GenerateHTTPResponseSample.cpp srcs/GenerateHTTPResponse.cpp srcs/HTTPRequestParser.cpp srcs/TOMLParser.cpp srcs/HTTPRequest.cpp srcs/StatusCodes.cpp srcs/PrintResponse.cpp && ./a.out
*/

int main() {
  try {
    HTTPRequestParser parser;

    // クライアントからデータを受信したと仮定
    const char* requestData =
        "GET / HTTP/1.1\r\n"
        "Host: localhost\r\n"
        "User-Agent: Mozilla/5.0\r\n"
        "\r\n";

    if (parser.feed(requestData, strlen(requestData))) {
      if (parser.hasError()) {
        std::cout << "解析エラー: " << parser.getErrorMessage() << std::endl;
      } else {
        ;  //	解析完了
      }
    } else {
      std::cout << "解析が未完了 - さらにデータが必要" << std::endl;
    }

    HTTPRequest httpRequest = parser.createRequest();

    TOMLParser toml_parser;
    Directive* rootDirective =
    toml_parser.parseFromFile("./conf/webserv.conf");
    printDirective(*rootDirective);
    std::cout << "====================" << std::endl;

    // HTTPレスポンスオブジェクトを作成
    HTTPResponse httpResponse;
    // 404 Not Foundエラーを設定
    httpResponse.setHttpStatusCode(500);

    // GenerateHTTPResponseオブジェクトを作成
    GenerateHTTPResponse GenerateHTTPResponse(*rootDirective, httpRequest);

    // GenerateHTTPResponseオブジェクトの次のハンドラをPrintResponseオブジェクトに設定
    PrintResponse printResponse;
    GenerateHTTPResponse.setNextHandler(&printResponse);

    // GenerateHTTPResponseオブジェクトを実行
    GenerateHTTPResponse.handleRequest(httpResponse);
    return 0;
  } catch (const std::exception& e) {
    std::cerr << "Error: " << e.what() << std::endl;
    return 1;
  }
}
```