### PR TITLE
Fr/#70/read the cgi execution result as the http response body

### DIFF
--- a/srcs/GenerateHTTPResponse.cpp
+++ b/srcs/GenerateHTTPResponse.cpp
@@ -144,11 +144,24 @@ std::string GenerateHTTPResponse::getPathForHttpResponseBody(
   return rootValue + requestedURL;
 }
 
+// 「CGIが実行されたかどうか」は「CGI_PAGE指定のファイルが存在するかどうか」でわかる
+static bool CGIResponseExist(const std::string& cgiPath) {
+  struct stat buffer;
+  // ファイルが存在するかどうかを確認
+  return (stat(cgiPath.c_str(), &buffer) == 0);
+}
+
 std::string GenerateHTTPResponse::generateHttpResponseBody(
     const int status_code, bool& pageFound) {
   std::string httpResponseBody;
 
-  httpResponseBody = readFile(getPathForHttpResponseBody(status_code));
+  // HTTPレスポンスがCGIの実行結果であるか
+  if (CGIResponseExist(CGI_PAGE)) {
+    httpResponseBody = readFile(CGI_PAGE);
+  } else {
+    httpResponseBody = readFile(getPathForHttpResponseBody(status_code));
+  }
+
   if (httpResponseBody.empty()) {
     httpResponseBody = readFile(DEFAULT_ERROR_PAGE);
     pageFound = false;

--- a/srcs/GenerateHTTPResponse.hpp
+++ b/srcs/GenerateHTTPResponse.hpp
@@ -1,11 +1,19 @@
 #pragma once
 
+#include <sys/stat.h>  //  for stat
+
 #include <fstream>  // ファイル入出力を行うためのヘッダ。std::ifstreamやstd::ofstreamなどのファイル入出力ストリームを提供。
 #include <sstream>  // 文字列のストリーム操作を行うためのヘッダ。std::stringstreamを使って文字列を組み立て、最終的に出力するために使用。
 
 #include "Handler.hpp"
 #include "StatusCodes.hpp"
+// #include "CGI.hpp" //  後に実装される
 #define DEFAULT_ERROR_PAGE "./html/defaultErrorPage.html"
+
+// CGI.hppで定義される．CGI.hppで定義された後，消す．
+#ifndef CGI_PAGE
+#define CGI_PAGE "./html/.cgi_response.html"
+#endif
 
 class GenerateHTTPResponse : public Handler {
  private:


### PR DESCRIPTION
This pull request introduces several changes to the `GenerateHTTPResponse` class, including the addition of a method to check for CGI responses, inclusion of necessary headers, and extensive tests for different scenarios of HTTP response generation.

### Enhancements to HTTP Response Generation:

* **Added CGI Response Check:**
  * Introduced the `CGIResponseExist` function to check if a CGI response file exists before generating the HTTP response body. (`srcs/GenerateHTTPResponse.cpp`)
  * Included the `sys/stat.h` header for file status checking. (`srcs/GenerateHTTPResponse.hpp`)

### Test Enhancements:

* **Unit Tests for HTTP Response Generation:**
  * Added a new test class `GetPathForHTTPResponseBodyTest` with multiple test cases to validate the behavior of `GenerateHTTPResponse::getPathForHttpResponseBody` under various conditions. (`test/srcs/GenerateHTTPResponseTest.cpp`)
  * Test cases include scenarios for custom error pages, default error pages, directory URLs, file URLs, missing host directives, missing root values, and different error status codes.