### PR TITLE
Fr/#76/not to set the http response body when the http method is delete

### DIFF
--- a/srcs/GenerateHTTPResponse.cpp
+++ b/srcs/GenerateHTTPResponse.cpp
@@ -153,6 +153,9 @@ static bool CGIResponseExist(const std::string& cgiPath) {
 
 std::string GenerateHTTPResponse::generateHttpResponseBody(
     const int status_code, bool& pageFound) {
+  // DELETEメソッドがコールされた場合，HTTPレスポンスボディを空にする
+  if (_httpRequest.getMethod() == "DELETE") return "";
+
   std::string httpResponseBody;
 
   // HTTPレスポンスがCGIの実行結果であるか

--- a/test/srcs/GenerateHTTPResponseTest.cpp
+++ b/test/srcs/GenerateHTTPResponseTest.cpp
@@ -574,3 +574,34 @@ TEST_F(GetPathForHTTPResponseBodyTest, DifferentErrorStatusCode) {
 
   EXPECT_EQ(body, defaultErrorPage);
 }
+
+// DELETEメソッドがコールされた場合，HTTPレスポンスボディを空にしているかテストする
+TEST(GerateHTTPResponseBodyTest, DeleteMethod) {
+  // テスト用のディレクティブを作成
+  Directive rootDirective("root");
+  Directive hostDirective("example.com");
+  hostDirective.addKeyValue("root", "./test_root");
+  rootDirective.addChild(hostDirective);
+
+  // リクエスト作成
+  std::map<std::string, std::string> headers;
+  headers["Host"] = "example.com";
+  HTTPRequest request("DELETE", "/some/path", "HTTP/1.1", headers, "");
+
+  // GenerateHTTPResponseインスタンスを作成
+  GenerateHTTPResponse GenerateHTTPResponse(rootDirective, request);
+
+  // HTTPResponseインスタンスを作成
+  HTTPResponse response;
+  response.setHttpStatusCode(200);
+
+  // handleRequestを呼び出す前のbodyを退避
+  std::string originalBody = "<!-- original body -->";
+  response.setHttpResponseBody(originalBody);
+
+  // handleRequestを呼び出す
+  GenerateHTTPResponse.handleRequest(response);
+
+  // DELETEメソッドの場合，HTTPレスポンスボディは空になる
+  EXPECT_EQ(response.getHttpResponseBody(), "");
+}


### PR DESCRIPTION
This pull request introduces changes to handle the HTTP DELETE method by ensuring that the HTTP response body is empty when a DELETE request is made. Additionally, a new test has been added to verify this behavior.

Key changes include:

### Handling DELETE Method:

* [`srcs/GenerateHTTPResponse.cpp`](diffhunk://#diff-0b379dc00a8fa789bd77f6e531779ce307ab14dd7de07a26fb173ba39050146aR156-R158): Added a condition to return an empty HTTP response body if the DELETE method is called.

### Testing DELETE Method:

* [`test/srcs/GenerateHTTPResponseTest.cpp`](diffhunk://#diff-ca59c666df0f556b4c2384d11c3a591ff9a0f84986010c5af5fc00ebfc741ea3R577-R607): Added a new test case `DeleteMethod` to verify that the HTTP response body is empty when a DELETE request is made.