### PR TITLE
ref: use the condition of cgi judgement

### DIFF
--- a/srcs/GenerateHTTPResponse.cpp
+++ b/srcs/GenerateHTTPResponse.cpp
@@ -158,7 +158,8 @@ std::string GenerateHTTPResponse::generateHttpResponseBody(
   std::string httpResponseBody;
 
   // HTTPレスポンスがCGIの実行結果であるか
-  if (endsWith(_httpRequest.getURL(), ".py") || endsWith(_httpRequest.getURL(), ".sh")) {
+  if (endsWith(_httpRequest.getURL(), ".py") ||
+      endsWith(_httpRequest.getURL(), ".sh")) {
     httpResponseBody = readFile(CGI_PAGE);
   } else {
     httpResponseBody = readFile(getPathForHttpResponseBody(status_code));

--- a/srcs/GenerateHTTPResponse.cpp
+++ b/srcs/GenerateHTTPResponse.cpp
@@ -144,11 +144,10 @@ std::string GenerateHTTPResponse::getPathForHttpResponseBody(
   return rootValue + requestedURL;
 }
 
-// 「CGIが実行されたかどうか」は「CGI_PAGE指定のファイルが存在するかどうか」でわかる
-static bool CGIResponseExist(const std::string& cgiPath) {
-  struct stat buffer;
-  // ファイルが存在するかどうかを確認
-  return (stat(cgiPath.c_str(), &buffer) == 0);
+// 指定された文字列が任意の文字列で終わるかを調べる関数
+bool endsWith(const std::string& str, const std::string& suffix) {
+  return str.size() >= suffix.size() &&
+         str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
 }
 
 std::string GenerateHTTPResponse::generateHttpResponseBody(
@@ -159,7 +158,7 @@ std::string GenerateHTTPResponse::generateHttpResponseBody(
   std::string httpResponseBody;
 
   // HTTPレスポンスがCGIの実行結果であるか
-  if (CGIResponseExist(CGI_PAGE)) {
+  if (endsWith(_httpRequest.getURL(), ".py") || endsWith(_httpRequest.getURL(), ".sh")) {
     httpResponseBody = readFile(CGI_PAGE);
   } else {
     httpResponseBody = readFile(getPathForHttpResponseBody(status_code));

--- a/srcs/GenerateHTTPResponse.hpp
+++ b/srcs/GenerateHTTPResponse.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <sys/stat.h>  //  for stat
-
 #include <fstream>  // ファイル入出力を行うためのヘッダ。std::ifstreamやstd::ofstreamなどのファイル入出力ストリームを提供。
 #include <sstream>  // 文字列のストリーム操作を行うためのヘッダ。std::stringstreamを使って文字列を組み立て、最終的に出力するために使用。
 


### PR DESCRIPTION
This pull request includes changes to the `GenerateHTTPResponse` class in `srcs/GenerateHTTPResponse.cpp` and its header file to improve the handling of HTTP response generation. The most important changes include replacing the `CGIResponseExist` function with a new `endsWith` function and updating the logic to determine if a CGI response should be generated.

Improvements to HTTP response generation:

* [`srcs/GenerateHTTPResponse.cpp`](diffhunk://#diff-0b379dc00a8fa789bd77f6e531779ce307ab14dd7de07a26fb173ba39050146aL147-R150): Removed the `CGIResponseExist` function and added a new `endsWith` function to check if a string ends with a specific suffix.
* [`srcs/GenerateHTTPResponse.cpp`](diffhunk://#diff-0b379dc00a8fa789bd77f6e531779ce307ab14dd7de07a26fb173ba39050146aL162-R161): Updated the `generateHttpResponseBody` method to use the `endsWith` function to check if the URL ends with `.py` or `.sh` to determine if a CGI response should be generated.

Code cleanup:

* [`srcs/GenerateHTTPResponse.hpp`](diffhunk://#diff-c84a0a4d0e69565218a98b43f442321360252beec7a88b2ee6e6903cf439bbe1L3-L4): Removed the unnecessary `#include <sys/stat.h>` directive as it is no longer needed after the removal of the `CGIResponseExist` function.