### PR TITLE
Fr/#84/implement listendirectory class

### DIFF
--- a/srcs/GenerateHTTPResponse.cpp
+++ b/srcs/GenerateHTTPResponse.cpp
@@ -145,7 +145,7 @@ std::string GenerateHTTPResponse::getPathForHttpResponseBody(
 }
 
 // 指定された文字列が任意の文字列で終わるかを調べる関数
-bool endsWith(const std::string& str, const std::string& suffix) {
+static bool endsWith(const std::string& str, const std::string& suffix) {
   return str.size() >= suffix.size() &&
          str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
 }

--- a/srcs/GenerateHTTPResponse.cpp
+++ b/srcs/GenerateHTTPResponse.cpp
@@ -179,23 +179,19 @@ std::string GenerateHTTPResponse::generateHttpResponseBody(
   // DELETEメソッドがコールされた場合，HTTPレスポンスボディを空にする
   if (_httpRequest.getMethod() == "DELETE") return "";
 
-  // autoindexがonの場合，ListenDirectoryクラスに処理を委譡する
-  if (status_code == 200 && getDirectiveValue("autoindex") == "on" &&
-      getDirectiveValue("root") != "") {
-    ListenDirectory listenDirectory(getDirectiveValue("root"));
-    HTTPResponse response;
-    listenDirectory.handleRequest(response);
-    // ディレクトリが開けない場合はpageFoundがfalseになる
-    pageFound = response.getHttpResponseBody().size() > 0;
-    return response.getHttpResponseBody();
-  }
-
   std::string httpResponseBody;
 
   // HTTPレスポンスがCGIの実行結果であるか
   if (endsWith(_httpRequest.getURL(), ".py") ||
       endsWith(_httpRequest.getURL(), ".sh")) {
     httpResponseBody = readFile(CGI_PAGE);
+  } // ディレクトリリスニングすべきか
+  else if (status_code == 200 && getDirectiveValue("autoindex") == "on" &&
+      getDirectiveValue("root") != "") {
+    ListenDirectory listenDirectory(getDirectiveValue("root"));
+    HTTPResponse response;
+    listenDirectory.handleRequest(response);
+    httpResponseBody = response.getHttpResponseBody();
   } else {
     httpResponseBody = readFile(getPathForHttpResponseBody(status_code));
   }

--- a/srcs/GenerateHTTPResponse.cpp
+++ b/srcs/GenerateHTTPResponse.cpp
@@ -35,38 +35,6 @@ std::string readFile(const std::string& filePath) {
   return buffer.str();
 }
 
-// DateのHTTPレスポンスヘッダは省略する．必要になったら設定する．
-// #include <ctime>  // 時刻の取得や操作を行うためのヘッダ。time(), gmtime(),
-// struct tmなどの機能を提供。 #include <iomanip>  //
-// 入力/出力のフォーマット設定を行うためのヘッダ。std::setfill('0')やstd::setw(2)など、表示フォーマットを制御するために使用。
-// std::string getCurrentTimeInGMTFormat() {
-//   // 現在の時刻を取得
-//   time_t rawtime;
-//   struct tm* timeinfo;
-//   time(&rawtime);
-//   timeinfo = gmtime(&rawtime);  // GMT(UTC)に変換
-
-//   // 曜日の配列
-//   const char* weekdays[] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
-//   // 月の配列
-//   const char* months[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
-//                           "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
-
-//   // 出力用の文字列ストリーム
-//   std::stringstream result;
-
-//   // 現在時刻を指定の形式でストリームに追加
-//   result << weekdays[timeinfo->tm_wday] << ", " << timeinfo->tm_mday << " "
-//          << months[timeinfo->tm_mon] << " " << (1900 + timeinfo->tm_year) <<
-//          " "
-//          << std::setfill('0') << std::setw(2) << timeinfo->tm_hour << ":"
-//          << std::setfill('0') << std::setw(2) << timeinfo->tm_min << ":"
-//          << std::setfill('0') << std::setw(2) << timeinfo->tm_sec << " GMT";
-
-//   // 結果を返す
-//   return result.str();
-// }
-
 std::string GenerateHTTPResponse::generateHttpResponseHeader(
     const std::string& httpResponseBody) {
   std::string httpResponseHeader = "Server: webserv\n";

--- a/srcs/GenerateHTTPResponse.cpp
+++ b/srcs/GenerateHTTPResponse.cpp
@@ -150,6 +150,30 @@ bool endsWith(const std::string& str, const std::string& suffix) {
          str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
 }
 
+std::string GenerateHTTPResponse::getDirectiveValue(std::string directiveKey) {
+  std::string directiveValue;
+  // 指定のホスト内の指定のロケーション内で指定ディレクティブdirectiveKeyの値があれば取得する
+  std::string requestedURL = _httpRequest.getURL();
+  if (isDirectory(requestedURL)) {
+    const Directive* locationDirective = _rootDirective.findDirective(
+        _httpRequest.getHeader("Host"), "location", requestedURL);
+    if (locationDirective != NULL) {
+      directiveValue = locationDirective->getValue(directiveKey);
+      if (!directiveValue.empty()) return directiveValue;
+    }
+  }
+
+  // 指定のホスト内で指定ディレクティブdirectiveKeyの値があれば取得する
+  const Directive* hostDirective =
+      _rootDirective.findDirective(_httpRequest.getHeader("Host"));
+  if (hostDirective != NULL) {
+    directiveValue = hostDirective->getValue(directiveKey);
+    if (!directiveValue.empty()) return directiveValue;
+  }
+
+  return "";
+}
+
 std::string GenerateHTTPResponse::generateHttpResponseBody(
     const int status_code, bool& pageFound) {
   // DELETEメソッドがコールされた場合，HTTPレスポンスボディを空にする

--- a/srcs/GenerateHTTPResponse.cpp
+++ b/srcs/GenerateHTTPResponse.cpp
@@ -180,7 +180,7 @@ std::string GenerateHTTPResponse::generateHttpResponseBody(
   if (_httpRequest.getMethod() == "DELETE") return "";
 
   // autoindexがonの場合，ListenDirectoryクラスに処理を委譡する
-  if (getDirectiveValue("autoindex") == "on" &&
+  if (status_code == 200 && getDirectiveValue("autoindex") == "on" &&
       getDirectiveValue("root") != "") {
     ListenDirectory listenDirectory(getDirectiveValue("root"));
     HTTPResponse response;

--- a/srcs/GenerateHTTPResponse.cpp
+++ b/srcs/GenerateHTTPResponse.cpp
@@ -179,6 +179,17 @@ std::string GenerateHTTPResponse::generateHttpResponseBody(
   // DELETEメソッドがコールされた場合，HTTPレスポンスボディを空にする
   if (_httpRequest.getMethod() == "DELETE") return "";
 
+  // autoindexがonの場合，ListenDirectoryクラスに処理を委譡する
+  if (getDirectiveValue("autoindex") == "on" &&
+      getDirectiveValue("root") != "") {
+    ListenDirectory listenDirectory(getDirectiveValue("root"));
+    HTTPResponse response;
+    listenDirectory.handleRequest(response);
+    // ディレクトリが開けない場合はpageFoundがfalseになる
+    pageFound = response.getHttpResponseBody().size() > 0;
+    return response.getHttpResponseBody();
+  }
+
   std::string httpResponseBody;
 
   // HTTPレスポンスがCGIの実行結果であるか

--- a/srcs/GenerateHTTPResponse.cpp
+++ b/srcs/GenerateHTTPResponse.cpp
@@ -185,9 +185,9 @@ std::string GenerateHTTPResponse::generateHttpResponseBody(
   if (endsWith(_httpRequest.getURL(), ".py") ||
       endsWith(_httpRequest.getURL(), ".sh")) {
     httpResponseBody = readFile(CGI_PAGE);
-  } // ディレクトリリスニングすべきか
+  }  // ディレクトリリスニングすべきか
   else if (status_code == 200 && getDirectiveValue("autoindex") == "on" &&
-      getDirectiveValue("root") != "") {
+           getDirectiveValue("root") != "") {
     ListenDirectory listenDirectory(getDirectiveValue("root"));
     HTTPResponse response;
     listenDirectory.handleRequest(response);

--- a/srcs/GenerateHTTPResponse.hpp
+++ b/srcs/GenerateHTTPResponse.hpp
@@ -5,6 +5,7 @@
 
 #include "CGI.hpp"
 #include "Handler.hpp"
+#include "ListenDirectory.hpp"
 #include "StatusCodes.hpp"
 #define DEFAULT_ERROR_PAGE "./html/defaultErrorPage.html"
 

--- a/srcs/GenerateHTTPResponse.hpp
+++ b/srcs/GenerateHTTPResponse.hpp
@@ -3,15 +3,10 @@
 #include <fstream>  // ファイル入出力を行うためのヘッダ。std::ifstreamやstd::ofstreamなどのファイル入出力ストリームを提供。
 #include <sstream>  // 文字列のストリーム操作を行うためのヘッダ。std::stringstreamを使って文字列を組み立て、最終的に出力するために使用。
 
+#include "CGI.hpp"
 #include "Handler.hpp"
 #include "StatusCodes.hpp"
-// #include "CGI.hpp" //  後に実装される
 #define DEFAULT_ERROR_PAGE "./html/defaultErrorPage.html"
-
-// CGI.hppで定義される．CGI.hppで定義された後，消す．
-#ifndef CGI_PAGE
-#define CGI_PAGE "./html/.cgi_response.html"
-#endif
 
 class GenerateHTTPResponse : public Handler {
  private:

--- a/srcs/GenerateHTTPResponse.hpp
+++ b/srcs/GenerateHTTPResponse.hpp
@@ -22,6 +22,7 @@ class GenerateHTTPResponse : public Handler {
   std::string generateHttpResponseBody(const int status_code, bool& pageFound);
   // utils
   std::string getPathForHttpResponseBody(const int status_code);
+  std::string getDirectiveValue(std::string directiveKey);
 
  public:
   GenerateHTTPResponse(Directive rootDirective, HTTPRequest httpRequest);

--- a/srcs/ListenDirectory.cpp
+++ b/srcs/ListenDirectory.cpp
@@ -1,0 +1,144 @@
+#include "ListenDirectory.hpp"
+
+#include <dirent.h>
+#include <sys/stat.h>
+#include <unistd.h>  // アクセス権限チェック用
+
+#include <algorithm>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
+
+// ディレクトリエントリの情報を格納する構造体
+struct DirectoryEntry {
+  std::string name;
+  bool isDirectory;
+
+  // ソート用の比較演算子
+  bool operator<(const DirectoryEntry& other) const {
+    // ディレクトリを先に表示
+    if (isDirectory != other.isDirectory)
+      return isDirectory > other.isDirectory;
+    // 同じタイプならアルファベット順
+    return name < other.name;
+  }
+};
+
+// 整数を文字列に変換
+std::string int2str(size_t value) {
+  std::stringstream ss;
+  ss << value;
+  return ss.str();
+}
+
+// コンストラクタの実装
+ListenDirectory::ListenDirectory(const std::string& dirpath)
+    : _dirpath(dirpath) {}
+
+void ListenDirectory::handleRequest(HTTPResponse& httpResponse) {
+  // 以前はhttpResponseからディレクトリパスを取得していましたが、
+  // 今はコンストラクタで設定された_dirpathを使用します
+  std::string dirPath = _dirpath;
+
+  // ディレクトリの読み取り権限と実行権限を確認
+  if (access(dirPath.c_str(), R_OK | X_OK) != 0) {
+    // 権限がない場合は空のボディを設定
+    httpResponse.setHttpResponseBody("");
+    return;
+  }
+
+  // ディレクトリが存在するか確認
+  DIR* dir = opendir(dirPath.c_str());
+  if (!dir) {
+    // ディレクトリが開けない場合は空のボディを設定
+    httpResponse.setHttpResponseBody("");
+    return;
+  }
+
+  // ディレクトリエントリの収集
+  std::vector<DirectoryEntry> entries;
+  struct dirent* entry;
+  while ((entry = readdir(dir)) != NULL) {
+    // "."は表示しない（".."は親ディレクトリへのリンクとして表示）
+    if (std::string(entry->d_name) == ".") continue;
+
+    DirectoryEntry dirEntry;
+    dirEntry.name = entry->d_name;
+
+    // ファイル情報の取得
+    struct stat statBuf;
+    std::string fullPath = dirPath + "/" + entry->d_name;
+    if (stat(fullPath.c_str(), &statBuf) == 0) {
+      dirEntry.isDirectory = S_ISDIR(statBuf.st_mode);
+    } else {
+      dirEntry.isDirectory = false;
+    }
+
+    entries.push_back(dirEntry);
+  }
+  closedir(dir);
+
+  // エントリをソート
+  std::sort(entries.begin(), entries.end());
+
+  // HTMLの生成
+  std::stringstream html;
+  html << "<!DOCTYPE html>\n"
+       << "<html>\n"
+       << "<head>\n"
+       << "    <meta charset=\"utf-8\">\n"
+       << "    <title>Directory listing for " << dirPath << "</title>\n"
+       << "    <style>\n"
+       << "        body { font-family: Arial, sans-serif; margin: 0; padding: "
+          "20px; }\n"
+       << "        h1 { border-bottom: 1px solid #ddd; margin-bottom: 20px; "
+          "padding-bottom: 10px; }\n"
+       << "        table { border-collapse: collapse; width: 100%; }\n"
+       << "        th, td { text-align: left; padding: 8px; }\n"
+       << "        tr:nth-child(even) { background-color: #f2f2f2; }\n"
+       << "        th { background-color: #4CAF50; color: white; }\n"
+       << "        a { text-decoration: none; color: #0066cc; }\n"
+       << "        a:hover { text-decoration: underline; }\n"
+       << "    </style>\n"
+       << "</head>\n"
+       << "<body>\n"
+       << "    <h1>Directory listing for " << dirPath << "</h1>\n"
+       << "    <table>\n"
+       << "        <tr>\n"
+       << "            <th>Name</th>\n"
+       << "        </tr>\n";
+
+  // 親ディレクトリへのリンク
+  html << "        <tr>\n"
+       << "            <td><a href=\"../\">Parent Directory</a></td>\n"
+       << "        </tr>\n";
+
+  // ディレクトリとファイルのエントリ
+  for (size_t i = 0; i < entries.size(); ++i) {
+    const DirectoryEntry& entry = entries[i];
+    html << "        <tr>\n"
+         << "            <td><a href=\"" << entry.name;
+
+    // ディレクトリの場合は末尾に/を追加
+    if (entry.isDirectory) html << "/";
+
+    html << "\">" << entry.name;
+
+    // ディレクトリの場合は末尾に/を追加
+    if (entry.isDirectory) html << "/";
+
+    html << "</a></td>\n"
+         << "        </tr>\n";
+  }
+
+  html << "    </table>\n"
+       << "</body>\n"
+       << "</html>";
+
+  // レスポンスの設定（ボディのみ）
+  std::string htmlContent = html.str();
+  httpResponse.setHttpResponseBody(htmlContent);
+
+  // 連鎖的なハンドラ処理
+  if (_nextHandler) _nextHandler->handleRequest(httpResponse);
+}

--- a/srcs/ListenDirectory.hpp
+++ b/srcs/ListenDirectory.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "Handler.hpp"
+
+// 前方宣言
+std::string int2str(size_t value);
+
+class ListenDirectory : public Handler {
+ private:
+  std::string _dirpath;  // ディレクトリパスを保持するメンバ変数
+
+ public:
+  ListenDirectory(const std::string& dirpath);
+  void handleRequest(HTTPResponse& httpResponse);
+};

--- a/test/srcs/ListenDirectoryTest.cpp
+++ b/test/srcs/ListenDirectoryTest.cpp
@@ -1,0 +1,167 @@
+#include <dirent.h>
+#include <gtest/gtest.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <fstream>
+
+#include "../../srcs/HTTPResponse.hpp"
+#include "../../srcs/ListenDirectory.hpp"
+
+// テスト用の次のハンドラー
+class MockHandler : public Handler {
+ public:
+  bool handlerCalled;
+
+  MockHandler() : handlerCalled(false) {}
+  void handleRequest(HTTPResponse& httpResponse) { handlerCalled = true; }
+};
+
+// テストフィクスチャ
+class ListenDirectoryTest : public ::testing::Test {
+ protected:
+  std::string testDirPath;
+  std::string subDirPath;
+  std::string testFilePath1;
+  std::string testFilePath2;
+  std::string specialFilePath;
+
+  void SetUp() override {
+    // テスト用ディレクトリのセットアップ
+    testDirPath = "./test_dir";
+    subDirPath = testDirPath + "/subdir";
+    testFilePath1 = testDirPath + "/file1.txt";
+    testFilePath2 = testDirPath + "/file2.txt";
+    specialFilePath = testDirPath + "/special file with spaces.txt";
+
+    // テストディレクトリを作成
+    mkdir(testDirPath.c_str(), 0755);
+    mkdir(subDirPath.c_str(), 0755);
+
+    // テストファイルを作成
+    std::ofstream file1(testFilePath1.c_str());
+    file1 << "This is test file 1" << std::endl;
+    file1.close();
+
+    std::ofstream file2(testFilePath2.c_str());
+    file2 << "This is test file 2 with more content" << std::endl;
+    file2 << "Second line" << std::endl;
+    file2.close();
+
+    std::ofstream specialFile(specialFilePath.c_str());
+    specialFile << "File with special characters in name" << std::endl;
+    specialFile.close();
+  }
+
+  void TearDown() override {
+    // テスト用のファイルとディレクトリを削除
+    if (access(testFilePath1.c_str(), F_OK) != -1) {
+      remove(testFilePath1.c_str());
+    }
+    if (access(testFilePath2.c_str(), F_OK) != -1) {
+      remove(testFilePath2.c_str());
+    }
+    if (access(specialFilePath.c_str(), F_OK) != -1) {
+      remove(specialFilePath.c_str());
+    }
+    if (access(subDirPath.c_str(), F_OK) != -1) {
+      rmdir(subDirPath.c_str());
+    }
+    if (access(testDirPath.c_str(), F_OK) != -1) {
+      rmdir(testDirPath.c_str());
+    }
+  }
+
+  // HTMLレスポンスに特定の文字列が含まれているかチェックするヘルパー関数
+  bool responseContains(const std::string& response, const std::string& text) {
+    return response.find(text) != std::string::npos;
+  }
+};
+
+// 正常系: 有効なディレクトリに対するテスト
+TEST_F(ListenDirectoryTest, ValidDirectory) {
+  ListenDirectory listenDir(testDirPath);
+  HTTPResponse response;
+
+  listenDir.handleRequest(response);
+
+  std::string body = response.getHttpResponseBody();
+
+  // ボディが空でないことを確認
+  EXPECT_FALSE(body.empty());
+
+  // ディレクトリ名がタイトルに含まれているか
+  EXPECT_TRUE(responseContains(body, "Directory listing for " + testDirPath));
+
+  // すべてのファイルとディレクトリが表示されているか
+  EXPECT_TRUE(responseContains(body, "file1.txt"));
+  EXPECT_TRUE(responseContains(body, "file2.txt"));
+  EXPECT_TRUE(responseContains(body, "special file with spaces.txt"));
+  EXPECT_TRUE(responseContains(body, "subdir/"));
+
+  // 親ディレクトリへのリンクがあるか
+  EXPECT_TRUE(responseContains(body, "Parent Directory"));
+
+  // Last ModifiedとSizeの列がないことを確認
+  EXPECT_FALSE(responseContains(body, "Last Modified"));
+  EXPECT_FALSE(responseContains(body, "Size"));
+}
+
+// 異常系: 存在しないディレクトリに対するテスト
+TEST_F(ListenDirectoryTest, NonExistentDirectory) {
+  ListenDirectory listenDir("./non_existent_directory");
+  HTTPResponse response;
+
+  listenDir.handleRequest(response);
+
+  // ボディが空であることを確認
+  EXPECT_TRUE(response.getHttpResponseBody().empty());
+}
+
+// 正常系: 空のディレクトリに対するテスト
+TEST_F(ListenDirectoryTest, EmptyDirectory) {
+  std::string emptyDir = "./empty_dir";
+  mkdir(emptyDir.c_str(), 0755);
+
+  ListenDirectory listenDir(emptyDir);
+  HTTPResponse response;
+
+  listenDir.handleRequest(response);
+
+  std::string body = response.getHttpResponseBody();
+
+  // ボディが空でないことを確認
+  EXPECT_FALSE(body.empty());
+
+  // 空ディレクトリでも親ディレクトリへのリンクがあるか
+  EXPECT_TRUE(responseContains(body, "Parent Directory"));
+
+  // テスト後にディレクトリを削除
+  rmdir(emptyDir.c_str());
+}
+
+// ハンドラーチェーンのテスト: 次のハンドラーが呼ばれるか
+TEST_F(ListenDirectoryTest, NextHandlerCalled) {
+  ListenDirectory listenDir(testDirPath);
+  MockHandler mockHandler;
+  listenDir.setNextHandler(&mockHandler);
+
+  HTTPResponse response;
+
+  listenDir.handleRequest(response);
+
+  // 次のハンドラーが呼ばれたか検証
+  EXPECT_TRUE(mockHandler.handlerCalled);
+}
+
+// ハンドラーチェーンのテスト: 次のハンドラーがない場合
+TEST_F(ListenDirectoryTest, NoNextHandler) {
+  ListenDirectory listenDir(testDirPath);
+
+  HTTPResponse response;
+
+  // エラーなく実行できることを検証
+  EXPECT_NO_THROW(listenDir.handleRequest(response));
+  EXPECT_FALSE(response.getHttpResponseBody().empty());
+}


### PR DESCRIPTION
This pull request introduces significant changes to the `GenerateHTTPResponse` class and adds a new `ListenDirectory` class to handle directory listing. Additionally, it includes modifications to the header files and introduces new tests for the `ListenDirectory` class.

Key changes include:

### Enhancements to `GenerateHTTPResponse`:

* Added a new method `getDirectiveValue` to retrieve directive values based on the request URL and host. [[1]](diffhunk://#diff-0b379dc00a8fa789bd77f6e531779ce307ab14dd7de07a26fb173ba39050146aL148-R192) [[2]](diffhunk://#diff-c84a0a4d0e69565218a98b43f442321360252beec7a88b2ee6e6903cf439bbe1R21)
* Integrated `ListenDirectory` to handle directory listings when `autoindex` is enabled.

### New `ListenDirectory` Class:

* Implemented the `ListenDirectory` class to generate HTML directory listings. [[1]](diffhunk://#diff-b6ffd4cb777c5f5ac63841d4d15e6fef7ecb06896bd64d00dd431ebfe19bf82aR1-R144) [[2]](diffhunk://#diff-f6a4849c06881877a1de54a1e3984bd888323b271c362f5ccb9ad91478d0bc60R1-R18)
* Added the ability to handle directory requests and generate appropriate HTML responses.

### Header File Updates:

* Included `CGI.hpp` and `ListenDirectory.hpp` in `GenerateHTTPResponse.hpp` to support the new functionality.
* Added a declaration for the new `getDirectiveValue` method in `GenerateHTTPResponse.hpp`.

### Testing:

* Added comprehensive tests for the `ListenDirectory` class, including tests for valid directories, non-existent directories, empty directories, and handler chaining.