### PR TITLE
Dockerfile: add siege for load testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install -y \
     make \
     curl \
     lcov \
+    siege \
     && apt-get clean
 
 RUN pip3 install pytest


### PR DESCRIPTION
#92 


## Summary
This pull request includes a small change to the `Dockerfile`. The change adds the `siege` package to the list of installed packages in the `RUN apt-get update && apt-get install -y` command.
