### PR TITLE
Fr/#96/implement post class

### DIFF
--- a/srcs/POST.cpp
+++ b/srcs/POST.cpp
@@ -1,0 +1,259 @@
+#include "POST.hpp"
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+POST::POST(Directive rootDirective, HTTPRequest httpRequest)
+    : _rootDirective(rootDirective), _httpRequest(httpRequest) {}
+
+// 完全なファイルパスを取得する関数
+std::string POST::getFullPath() const {
+  // ホストディレクティブからrootの値を取得
+  std::string rootValue;
+  const Directive* hostDirective =
+      _rootDirective.findDirective(_httpRequest.getHeader("Host"));
+  if (hostDirective != NULL) {
+    rootValue = hostDirective->getValue("root");
+  }
+
+  // URLとrootを結合して完全なパスを作成
+  return rootValue + _httpRequest.getURL();
+}
+
+// ファイルが存在するか確認する関数
+bool POST::fileExists(const std::string& filePath) const {
+  struct stat buffer;
+  return (stat(filePath.c_str(), &buffer) == 0 && S_ISREG(buffer.st_mode));
+}
+
+// ディレクトリが存在するか確認する関数
+bool POST::directoryExists(const std::string& dirPath) const {
+  struct stat buffer;
+  return (stat(dirPath.c_str(), &buffer) == 0 && S_ISDIR(buffer.st_mode));
+}
+
+// ファイルまたはディレクトリへの書き込み権限があるか確認する関数
+bool POST::hasWritePermission(const std::string& path) const {
+  return access(path.c_str(), W_OK) == 0;
+}
+
+// リクエストボディサイズが制限内か確認する関数
+bool POST::isBodySizeAllowed(const std::string& body) const {
+  const Directive* hostDirective = 
+      _rootDirective.findDirective(_httpRequest.getHeader("Host"));
+  
+  if (hostDirective != NULL) {
+    std::string maxBodySizeStr = hostDirective->getValue("client_max_body_size");
+    if (!maxBodySizeStr.empty()) {
+      // クライアント最大ボディサイズを解析
+      size_t maxBodySize = 0;
+      std::istringstream iss(maxBodySizeStr);
+      iss >> maxBodySize;
+      
+      // サイズ単位（M, K, G）があれば考慮
+      if (iss.peek() == 'M' || iss.peek() == 'm') {
+        maxBodySize *= 1024 * 1024;  // メガバイト
+      } else if (iss.peek() == 'K' || iss.peek() == 'k') {
+        maxBodySize *= 1024;  // キロバイト
+      } else if (iss.peek() == 'G' || iss.peek() == 'g') {
+        maxBodySize *= 1024 * 1024 * 1024;  // ギガバイト
+      }
+      
+      return body.size() <= maxBodySize;
+    }
+  }
+  
+  // 制限が指定されていない場合はデフォルトで1MBに制限
+  return body.size() <= 1024 * 1024;
+}
+
+// 指定されたディレクトリにPOSTが許可されているか確認する関数
+bool POST::isPostAllowedForPath(const std::string& path) const {
+  // URLからパスを取得
+  std::string url = _httpRequest.getURL();
+  
+  // ディレクトリの場合は末尾に/を保証
+  std::string locationPath = url;
+  if (!locationPath.empty() && locationPath[locationPath.length() - 1] != '/') {
+    // 親ディレクトリを取得
+    size_t pos = locationPath.find_last_of('/');
+    if (pos != std::string::npos) {
+      locationPath = locationPath.substr(0, pos + 1);
+    }
+  }
+  
+  // locationディレクティブを探す
+  const Directive* locationDirective = 
+      _rootDirective.findDirective(_httpRequest.getHeader("Host"), "location", locationPath);
+  
+  if (locationDirective != NULL) {
+    // limit_except ディレクティブがあるかチェック
+    std::string allowedMethods = locationDirective->getValue("limit_except");
+    if (!allowedMethods.empty()) {
+      // POSTメソッドが許可されているか確認
+      return allowedMethods.find("POST") != std::string::npos;
+    } else {
+      // limit_exceptディレクティブがない場合はデフォルトで許可
+      return true;
+    }
+  }
+  
+  // ディレクティブが見つからない場合はデフォルトで許可
+  return true;
+}
+
+// チャンク転送エンコーディングを処理する関数
+std::string POST::processChunkedBody(const std::string& chunkedBody) {
+  std::string result;
+  size_t pos = 0;
+  
+  while (pos < chunkedBody.size()) {
+    // チャンクサイズを読み取る
+    size_t eol = chunkedBody.find("\r\n", pos);
+    if (eol == std::string::npos) break;
+    
+    std::string chunkSizeHex = chunkedBody.substr(pos, eol - pos);
+    // 16進数サイズを取得
+    size_t chunkSize = 0;
+    std::istringstream iss(chunkSizeHex);
+    iss >> std::hex >> chunkSize;
+    
+    // サイズが0ならチャンク終了
+    if (chunkSize == 0) break;
+    
+    // チャンクデータの開始位置
+    size_t dataStart = eol + 2;
+    if (dataStart + chunkSize <= chunkedBody.size()) {
+      // チャンクデータをresultに追加
+      result.append(chunkedBody, dataStart, chunkSize);
+      // 次のチャンクへ
+      pos = dataStart + chunkSize + 2;  // +2 for \r\n after chunk data
+    } else {
+      // チャンクデータが不完全
+      break;
+    }
+  }
+  
+  return result;
+}
+
+// ファイルにデータを書き込む関数
+bool POST::writeToFile(const std::string& filePath, const std::string& content) {
+  // ファイルを開く（既存ファイルは上書き）
+  std::ofstream file(filePath.c_str(), std::ios::binary | std::ios::trunc);
+  if (!file.is_open()) {
+    return false;
+  }
+  
+  // コンテンツを書き込む
+  file.write(content.c_str(), content.size());
+  bool success = !file.bad();
+  file.close();
+  
+  return success;
+}
+
+// HTTPステータスコードを設定する関数
+void POST::setHttpStatusCode(HTTPResponse& httpResponse, 
+                             const std::string& fullPath) {
+  std::string method = _httpRequest.getMethod();
+
+  // メソッド確認 (POSTでないなら405)
+  if (method != "POST") {
+    httpResponse.setHttpStatusCode(405);  // Method Not Allowed
+    return;
+  }
+  
+  // POSTメソッドが許可されているか確認
+  if (!isPostAllowedForPath(fullPath)) {
+    httpResponse.setHttpStatusCode(405);  // Method Not Allowed
+    return;
+  }
+
+  // リクエストボディのサイズ確認
+  std::string body = _httpRequest.getBody();
+  
+  // チャンク転送の場合はデコード
+  if (_httpRequest.getHeader("Transfer-Encoding") == "chunked") {
+    body = processChunkedBody(body);
+  }
+  
+  // ボディサイズ制限チェック
+  if (!isBodySizeAllowed(body)) {
+    httpResponse.setHttpStatusCode(413);  // Request Entity Too Large
+    return;
+  }
+
+  // ファイル/ディレクトリの存在確認
+  std::string dirPath = fullPath;
+  size_t lastSlash = dirPath.find_last_of('/');
+  if (lastSlash != std::string::npos) {
+    dirPath = dirPath.substr(0, lastSlash);
+  }
+
+  if (!directoryExists(dirPath)) {
+    httpResponse.setHttpStatusCode(404);  // Not Found
+    return;
+  }
+
+  // 書き込み権限の確認
+  if (!hasWritePermission(dirPath)) {
+    httpResponse.setHttpStatusCode(403);  // Forbidden
+    return;
+  }
+
+  // デフォルトは200 OK (後でhandlePostRequestで201に変更される可能性あり)
+  httpResponse.setHttpStatusCode(200);
+}
+
+// POSTリクエストを処理する関数
+bool POST::handlePostRequest(HTTPResponse& httpResponse, const std::string& fullPath) {
+  std::string body = _httpRequest.getBody();
+  
+  // チャンク転送の場合はデコード
+  if (_httpRequest.getHeader("Transfer-Encoding") == "chunked") {
+    body = processChunkedBody(body);
+  }
+  
+  // CGIスクリプトかどうか確認
+  if (fullPath.find(".py") != std::string::npos || 
+      fullPath.find(".sh") != std::string::npos) {
+    // CGIハンドラを呼び出す
+    CGI cgi = CGI(_rootDirective, _httpRequest);
+    cgi.handleRequest(httpResponse);
+    return true;
+  } else {
+    // 通常のファイル書き込み
+    if (writeToFile(fullPath, body)) {
+      httpResponse.setHttpStatusCode(201);  // Created
+      return true;
+    } else {
+      httpResponse.setHttpStatusCode(500);  // Internal Server Error
+      return false;
+    }
+  }
+}
+
+// HTTPレスポンスを処理する
+void POST::handleRequest(HTTPResponse& httpResponse) {
+  std::string fullPath = getFullPath();
+  
+  // HTTPステータスコードを設定
+  setHttpStatusCode(httpResponse, fullPath);
+  
+  // ステータスコードが200ならPOST処理を実行
+  if (httpResponse.getHttpStatusCode() == 200) {
+    handlePostRequest(httpResponse, fullPath);
+  }
+  
+  // チェーンの次のハンドラに処理を委譲
+  if (_nextHandler != NULL) {
+    _nextHandler->handleRequest(httpResponse);
+  }
+}

--- a/srcs/POST.hpp
+++ b/srcs/POST.hpp
@@ -13,10 +13,12 @@ class POST : public Handler {
   std::string getFullPath() const;
 
   // HTTPステータスコードを設定する関数
-  void setHttpStatusCode(HTTPResponse& httpResponse, const std::string& fullPath);
+  void setHttpStatusCode(HTTPResponse& httpResponse,
+                         const std::string& fullPath);
 
   // POSTリクエストを処理する関数
-  bool handlePostRequest(HTTPResponse& httpResponse, const std::string& fullPath);
+  bool handlePostRequest(HTTPResponse& httpResponse,
+                         const std::string& fullPath);
 
   // ファイルにデータを書き込む関数
   bool writeToFile(const std::string& filePath, const std::string& content);

--- a/srcs/POST.hpp
+++ b/srcs/POST.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "CGI.hpp"
+#include "GenerateHTTPResponse.hpp"
+#include "Handler.hpp"
+
+class POST : public Handler {
+ private:
+  Directive _rootDirective;
+  HTTPRequest _httpRequest;
+
+  // リクエストされたURLの完全なファイルパスを取得する関数
+  std::string getFullPath() const;
+
+  // HTTPステータスコードを設定する関数
+  void setHttpStatusCode(HTTPResponse& httpResponse, const std::string& fullPath);
+
+  // POSTリクエストを処理する関数
+  bool handlePostRequest(HTTPResponse& httpResponse, const std::string& fullPath);
+
+  // ファイルにデータを書き込む関数
+  bool writeToFile(const std::string& filePath, const std::string& content);
+
+  // チャンク転送エンコーディングを処理する関数
+  std::string processChunkedBody(const std::string& chunkedBody);
+
+  // ファイルが存在するか確認する関数
+  bool fileExists(const std::string& filePath) const;
+
+  // ディレクトリが存在するか確認する関数
+  bool directoryExists(const std::string& dirPath) const;
+
+  // ファイルまたはディレクトリへの書き込み権限があるか確認する関数
+  bool hasWritePermission(const std::string& path) const;
+
+  // リクエストボディサイズが制限内か確認する関数
+  bool isBodySizeAllowed(const std::string& body) const;
+
+  // 指定されたディレクトリにPOSTが許可されているか確認する関数
+  bool isPostAllowedForPath(const std::string& path) const;
+
+ public:
+  POST(Directive rootDirective, HTTPRequest httpRequest);
+  void handleRequest(HTTPResponse& httpResponse);
+};

--- a/test/srcs/POSTTest.cpp
+++ b/test/srcs/POSTTest.cpp
@@ -1,0 +1,310 @@
+#include <gtest/gtest.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+#include "../../srcs/POST.hpp"
+#include "../../srcs/Directive.hpp"
+#include "../../srcs/HTTPRequest.hpp"
+#include "../../srcs/HTTPResponse.hpp"
+
+// テスト用のヘルパー関数
+namespace {
+  // テスト用一時ファイルの作成
+  void createTempFile(const std::string& path, const std::string& content) {
+    std::ofstream file(path.c_str());
+    file << content;
+    file.close();
+  }
+
+  // テスト用ディレクトリの作成
+  bool createDirectory(const std::string& path) {
+    return mkdir(path.c_str(), 0755) == 0;
+  }
+
+  // ファイルの存在確認
+  bool fileExists(const std::string& path) {
+    struct stat buffer;
+    return (stat(path.c_str(), &buffer) == 0);
+  }
+
+  // ファイルの内容確認
+  std::string readFile(const std::string& path) {
+    std::ifstream file(path.c_str());
+    std::string content((std::istreambuf_iterator<char>(file)),
+                         std::istreambuf_iterator<char>());
+    return content;
+  }
+
+  // テスト用のディレクティブ構造を作成する関数
+  Directive createTestDirective(const std::string& host,
+                               const std::string& root,
+                               const std::string& maxBodySize,
+                               bool allowPost = true,
+                               const std::string& location = "/") {
+    Directive rootDirective("root");
+
+    // ホストディレクティブの作成
+    Directive hostDirective(host);
+    hostDirective.addKeyValue("root", root);
+    if (!maxBodySize.empty()) {
+      hostDirective.addKeyValue("client_max_body_size", maxBodySize);
+    }
+    
+    // locationディレクティブの作成
+    Directive locationDirective("location");
+    locationDirective.addKeyValue("path", location);
+    if (!allowPost) {
+      locationDirective.addKeyValue("limit_except", "GET");
+    } else {
+      locationDirective.addKeyValue("limit_except", "GET POST");
+    }
+    
+    hostDirective.addChild(locationDirective);
+    rootDirective.addChild(hostDirective);
+    
+    return rootDirective;
+  }
+}
+
+class POSTTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // テスト用ディレクトリの作成
+    createDirectory("./test_tmp");
+    createDirectory("./test_tmp/webroot");
+    createDirectory("./test_tmp/webroot/uploads");
+    
+    // テスト用ファイルの作成
+    createTempFile("./test_tmp/webroot/test.txt", "Hello World");
+    createTempFile("./test_tmp/webroot/test.py", "print('Content-type: text/html\\n\\nHello from Python')");
+    
+    // 書き込み権限のないディレクトリの作成
+    createDirectory("./test_tmp/webroot/no_permission");
+    chmod("./test_tmp/webroot/no_permission", 0500); // 読み込み・実行のみ許可
+  }
+
+  void TearDown() override {
+    // テストファイルの削除
+    system("rm -rf ./test_tmp");
+  }
+  
+  // 標準的なHTTPリクエストを作成する
+  HTTPRequest createPostRequest(const std::string& url,
+                               const std::string& body,
+                               const std::string& contentType = "text/plain",
+                               bool chunked = false) {
+    std::map<std::string, std::string> headers;
+    headers["Host"] = "localhost:8080";
+    headers["Content-Type"] = contentType;
+    
+    if (chunked) {
+      headers["Transfer-Encoding"] = "chunked";
+    } else {
+      std::stringstream ss;
+      ss << body.length();
+      headers["Content-Length"] = ss.str();
+    }
+    
+    return HTTPRequest("POST", url, "HTTP/1.1", headers, body);
+  }
+  
+  // チャンクエンコードされたボディを生成
+  std::string createChunkedBody(const std::string& body) {
+    std::stringstream result;
+    size_t pos = 0;
+    const size_t chunkSize = 5; // 小さいチャンクサイズでテスト
+    
+    while (pos < body.length()) {
+      size_t size = std::min(chunkSize, body.length() - pos);
+      std::stringstream hexSize;
+      hexSize << std::hex << size;
+      
+      result << hexSize.str() << "\r\n";
+      result << body.substr(pos, size) << "\r\n";
+      pos += size;
+    }
+    
+    result << "0\r\n\r\n"; // 終端チャンク
+    return result.str();
+  }
+};
+
+// 1. 基本的なPOSTリクエストのテスト
+TEST_F(POSTTest, BasicPostRequest) {
+  // 設定
+  Directive rootDirective = createTestDirective("localhost:8080", "./test_tmp/webroot", "1M");
+  HTTPRequest request = createPostRequest("/uploads/file.txt", "Test content");
+  HTTPResponse response;
+  
+  // テスト対象の実行
+  POST postHandler(rootDirective, request);
+  postHandler.handleRequest(response);
+  
+  // 検証
+  EXPECT_EQ(response.getHttpStatusCode(), 201);
+  EXPECT_TRUE(fileExists("./test_tmp/webroot/uploads/file.txt"));
+  EXPECT_EQ(readFile("./test_tmp/webroot/uploads/file.txt"), "Test content");
+}
+
+// 2. チャンク転送エンコーディングのテスト
+TEST_F(POSTTest, ChunkedTransferEncoding) {
+  // 設定
+  Directive rootDirective = createTestDirective("localhost:8080", "./test_tmp/webroot", "1M");
+  std::string originalBody = "This is a chunked test message";
+  std::string chunkedBody = createChunkedBody(originalBody);
+  
+  HTTPRequest request = createPostRequest("/uploads/chunked.txt", chunkedBody, "text/plain", true);
+  HTTPResponse response;
+  
+  // テスト対象の実行
+  POST postHandler(rootDirective, request);
+  postHandler.handleRequest(response);
+  
+  // 検証
+  EXPECT_EQ(response.getHttpStatusCode(), 201);
+  EXPECT_TRUE(fileExists("./test_tmp/webroot/uploads/chunked.txt"));
+  EXPECT_EQ(readFile("./test_tmp/webroot/uploads/chunked.txt"), originalBody);
+}
+
+// 3. 大きすぎるリクエストボディのテスト
+TEST_F(POSTTest, BodySizeTooLarge) {
+  // 設定
+  Directive rootDirective = createTestDirective("localhost:8080", "./test_tmp/webroot", "10");
+  std::string largeBody(100, 'X'); // 制限より大きいサイズ
+  HTTPRequest request = createPostRequest("/uploads/large.txt", largeBody);
+  HTTPResponse response;
+  
+  // テスト対象の実行
+  POST postHandler(rootDirective, request);
+  postHandler.handleRequest(response);
+  
+  // 検証
+  EXPECT_EQ(response.getHttpStatusCode(), 413); // Request Entity Too Large
+  EXPECT_FALSE(fileExists("./test_tmp/webroot/uploads/large.txt"));
+}
+
+// 4. 存在しないディレクトリへのPOSTテスト
+TEST_F(POSTTest, NonExistentDirectory) {
+  // 設定
+  Directive rootDirective = createTestDirective("localhost:8080", "./test_tmp/webroot", "1M");
+  HTTPRequest request = createPostRequest("/non_existent/file.txt", "Test content");
+  HTTPResponse response;
+  
+  // テスト対象の実行
+  POST postHandler(rootDirective, request);
+  postHandler.handleRequest(response);
+  
+  // 検証
+  EXPECT_EQ(response.getHttpStatusCode(), 404); // Not Found
+}
+
+// 5. 権限のないディレクトリへのPOSTテスト
+TEST_F(POSTTest, NoPermissionDirectory) {
+  // 設定
+  Directive rootDirective = createTestDirective("localhost:8080", "./test_tmp/webroot", "1M");
+  HTTPRequest request = createPostRequest("/no_permission/file.txt", "Test content");
+  HTTPResponse response;
+  
+  // テスト対象の実行
+  POST postHandler(rootDirective, request);
+  postHandler.handleRequest(response);
+  
+  // 検証
+  EXPECT_EQ(response.getHttpStatusCode(), 403); // Forbidden
+}
+
+// 6. POSTメソッドが許可されていないパスへのPOSTテスト
+TEST_F(POSTTest, MethodNotAllowed) {
+  // POSTが許可されていないディレクティブを作成
+  Directive rootDirective = createTestDirective("localhost:8080", "./test_tmp/webroot", "1M", false);
+  HTTPRequest request = createPostRequest("/uploads/not_allowed.txt", "Test content");
+  HTTPResponse response;
+  
+  // テスト対象の実行
+  POST postHandler(rootDirective, request);
+  postHandler.handleRequest(response);
+  
+  // 検証
+  EXPECT_EQ(response.getHttpStatusCode(), 405); // Method Not Allowed
+}
+
+// 7. 不正なメソッドのテスト
+TEST_F(POSTTest, InvalidMethod) {
+  // 設定
+  Directive rootDirective = createTestDirective("localhost:8080", "./test_tmp/webroot", "1M");
+  // POSTハンドラにGETメソッドのリクエストを渡す
+  std::map<std::string, std::string> headers;
+  headers["Host"] = "localhost:8080";
+  HTTPRequest request("GET", "/uploads/file.txt", "HTTP/1.1", headers, "");
+  HTTPResponse response;
+  
+  // テスト対象の実行
+  POST postHandler(rootDirective, request);
+  postHandler.handleRequest(response);
+  
+  // 検証
+  EXPECT_EQ(response.getHttpStatusCode(), 405); // Method Not Allowed
+}
+
+// 8. CGIスクリプトへのPOSTテスト
+TEST_F(POSTTest, PostToCgiScript) {
+  // 設定
+  Directive rootDirective = createTestDirective("localhost:8080", "./test_tmp/webroot", "1M");
+  HTTPRequest request = createPostRequest("/test.py", "name=John&age=30", "application/x-www-form-urlencoded");
+  HTTPResponse response;
+  
+  // テスト対象の実行
+  POST postHandler(rootDirective, request);
+  postHandler.handleRequest(response);
+  
+  // 検証 - 実際のCGI実行結果は環境に依存するため、ステータスコードのみ検証
+  // CGI実行が成功したかどうかは実際の環境に依存しますが、
+  // ハンドラーが適切に呼び出されていることを確認します
+  EXPECT_TRUE(response.getHttpStatusCode() == 200 || 
+              response.getHttpStatusCode() == 500);
+}
+
+// 9. サイズ制限が指定されていない場合のデフォルト制限のテスト
+TEST_F(POSTTest, DefaultSizeLimit) {
+  // 設定 - client_max_body_sizeを指定しない
+  Directive rootDirective = createTestDirective("localhost:8080", "./test_tmp/webroot", "");
+  
+  // デフォルト制限（1MB）より小さいボディ
+  std::string smallBody(1024, 'X'); // 1KB
+  HTTPRequest request = createPostRequest("/uploads/small.txt", smallBody);
+  HTTPResponse response;
+  
+  // テスト対象の実行
+  POST postHandler(rootDirective, request);
+  postHandler.handleRequest(response);
+  
+  // 検証
+  EXPECT_EQ(response.getHttpStatusCode(), 201);
+  EXPECT_TRUE(fileExists("./test_tmp/webroot/uploads/small.txt"));
+}
+
+// 10. 空のボディのPOSTテスト
+TEST_F(POSTTest, EmptyBody) {
+  // 設定
+  Directive rootDirective = createTestDirective("localhost:8080", "./test_tmp/webroot", "1M");
+  HTTPRequest request = createPostRequest("/uploads/empty.txt", "");
+  HTTPResponse response;
+  
+  // テスト対象の実行
+  POST postHandler(rootDirective, request);
+  postHandler.handleRequest(response);
+  
+  // 検証
+  EXPECT_EQ(response.getHttpStatusCode(), 201);
+  EXPECT_TRUE(fileExists("./test_tmp/webroot/uploads/empty.txt"));
+  EXPECT_EQ(readFile("./test_tmp/webroot/uploads/empty.txt"), "");
+}
+
+// メインテスト実行関数
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/srcs/POSTTest.cpp
+++ b/test/srcs/POSTTest.cpp
@@ -1,73 +1,73 @@
 #include <gtest/gtest.h>
 #include <sys/stat.h>
 #include <unistd.h>
+
 #include <fstream>
 #include <iostream>
 #include <string>
 
-#include "../../srcs/POST.hpp"
 #include "../../srcs/Directive.hpp"
 #include "../../srcs/HTTPRequest.hpp"
 #include "../../srcs/HTTPResponse.hpp"
+#include "../../srcs/POST.hpp"
 
 // テスト用のヘルパー関数
 namespace {
-  // テスト用一時ファイルの作成
-  void createTempFile(const std::string& path, const std::string& content) {
-    std::ofstream file(path.c_str());
-    file << content;
-    file.close();
-  }
-
-  // テスト用ディレクトリの作成
-  bool createDirectory(const std::string& path) {
-    return mkdir(path.c_str(), 0755) == 0;
-  }
-
-  // ファイルの存在確認
-  bool fileExists(const std::string& path) {
-    struct stat buffer;
-    return (stat(path.c_str(), &buffer) == 0);
-  }
-
-  // ファイルの内容確認
-  std::string readFile(const std::string& path) {
-    std::ifstream file(path.c_str());
-    std::string content((std::istreambuf_iterator<char>(file)),
-                         std::istreambuf_iterator<char>());
-    return content;
-  }
-
-  // テスト用のディレクティブ構造を作成する関数
-  Directive createTestDirective(const std::string& host,
-                               const std::string& root,
-                               const std::string& maxBodySize,
-                               bool allowPost = true,
-                               const std::string& location = "/") {
-    Directive rootDirective("root");
-
-    // ホストディレクティブの作成
-    Directive hostDirective(host);
-    hostDirective.addKeyValue("root", root);
-    if (!maxBodySize.empty()) {
-      hostDirective.addKeyValue("client_max_body_size", maxBodySize);
-    }
-    
-    // locationディレクティブの作成
-    Directive locationDirective("location");
-    locationDirective.addKeyValue("path", location);
-    if (!allowPost) {
-      locationDirective.addKeyValue("limit_except", "GET");
-    } else {
-      locationDirective.addKeyValue("limit_except", "GET POST");
-    }
-    
-    hostDirective.addChild(locationDirective);
-    rootDirective.addChild(hostDirective);
-    
-    return rootDirective;
-  }
+// テスト用一時ファイルの作成
+void createTempFile(const std::string& path, const std::string& content) {
+  std::ofstream file(path.c_str());
+  file << content;
+  file.close();
 }
+
+// テスト用ディレクトリの作成
+bool createDirectory(const std::string& path) {
+  return mkdir(path.c_str(), 0755) == 0;
+}
+
+// ファイルの存在確認
+bool fileExists(const std::string& path) {
+  struct stat buffer;
+  return (stat(path.c_str(), &buffer) == 0);
+}
+
+// ファイルの内容確認
+std::string readFile(const std::string& path) {
+  std::ifstream file(path.c_str());
+  std::string content((std::istreambuf_iterator<char>(file)),
+                      std::istreambuf_iterator<char>());
+  return content;
+}
+
+// テスト用のディレクティブ構造を作成する関数
+Directive createTestDirective(const std::string& host, const std::string& root,
+                              const std::string& maxBodySize,
+                              bool allowPost = true,
+                              const std::string& location = "/") {
+  Directive rootDirective("root");
+
+  // ホストディレクティブの作成
+  Directive hostDirective(host);
+  hostDirective.addKeyValue("root", root);
+  if (!maxBodySize.empty()) {
+    hostDirective.addKeyValue("client_max_body_size", maxBodySize);
+  }
+
+  // locationディレクティブの作成
+  Directive locationDirective("location");
+  locationDirective.addKeyValue("path", location);
+  if (!allowPost) {
+    locationDirective.addKeyValue("limit_except", "GET");
+  } else {
+    locationDirective.addKeyValue("limit_except", "GET POST");
+  }
+
+  hostDirective.addChild(locationDirective);
+  rootDirective.addChild(hostDirective);
+
+  return rootDirective;
+}
+}  // namespace
 
 class POSTTest : public ::testing::Test {
  protected:
@@ -76,30 +76,30 @@ class POSTTest : public ::testing::Test {
     createDirectory("./test_tmp");
     createDirectory("./test_tmp/webroot");
     createDirectory("./test_tmp/webroot/uploads");
-    
+
     // テスト用ファイルの作成
     createTempFile("./test_tmp/webroot/test.txt", "Hello World");
-    createTempFile("./test_tmp/webroot/test.py", "print('Content-type: text/html\\n\\nHello from Python')");
-    
+    createTempFile("./test_tmp/webroot/test.py",
+                   "print('Content-type: text/html\\n\\nHello from Python')");
+
     // 書き込み権限のないディレクトリの作成
     createDirectory("./test_tmp/webroot/no_permission");
-    chmod("./test_tmp/webroot/no_permission", 0500); // 読み込み・実行のみ許可
+    chmod("./test_tmp/webroot/no_permission", 0500);  // 読み込み・実行のみ許可
   }
 
   void TearDown() override {
     // テストファイルの削除
     system("rm -rf ./test_tmp");
   }
-  
+
   // 標準的なHTTPリクエストを作成する
-  HTTPRequest createPostRequest(const std::string& url,
-                               const std::string& body,
-                               const std::string& contentType = "text/plain",
-                               bool chunked = false) {
+  HTTPRequest createPostRequest(const std::string& url, const std::string& body,
+                                const std::string& contentType = "text/plain",
+                                bool chunked = false) {
     std::map<std::string, std::string> headers;
     headers["Host"] = "localhost:8080";
     headers["Content-Type"] = contentType;
-    
+
     if (chunked) {
       headers["Transfer-Encoding"] = "chunked";
     } else {
@@ -107,27 +107,27 @@ class POSTTest : public ::testing::Test {
       ss << body.length();
       headers["Content-Length"] = ss.str();
     }
-    
+
     return HTTPRequest("POST", url, "HTTP/1.1", headers, body);
   }
-  
+
   // チャンクエンコードされたボディを生成
   std::string createChunkedBody(const std::string& body) {
     std::stringstream result;
     size_t pos = 0;
-    const size_t chunkSize = 5; // 小さいチャンクサイズでテスト
-    
+    const size_t chunkSize = 5;  // 小さいチャンクサイズでテスト
+
     while (pos < body.length()) {
       size_t size = std::min(chunkSize, body.length() - pos);
       std::stringstream hexSize;
       hexSize << std::hex << size;
-      
+
       result << hexSize.str() << "\r\n";
       result << body.substr(pos, size) << "\r\n";
       pos += size;
     }
-    
-    result << "0\r\n\r\n"; // 終端チャンク
+
+    result << "0\r\n\r\n";  // 終端チャンク
     return result.str();
   }
 };
@@ -135,14 +135,15 @@ class POSTTest : public ::testing::Test {
 // 1. 基本的なPOSTリクエストのテスト
 TEST_F(POSTTest, BasicPostRequest) {
   // 設定
-  Directive rootDirective = createTestDirective("localhost:8080", "./test_tmp/webroot", "1M");
+  Directive rootDirective =
+      createTestDirective("localhost:8080", "./test_tmp/webroot", "1M");
   HTTPRequest request = createPostRequest("/uploads/file.txt", "Test content");
   HTTPResponse response;
-  
+
   // テスト対象の実行
   POST postHandler(rootDirective, request);
   postHandler.handleRequest(response);
-  
+
   // 検証
   EXPECT_EQ(response.getHttpStatusCode(), 201);
   EXPECT_TRUE(fileExists("./test_tmp/webroot/uploads/file.txt"));
@@ -152,17 +153,19 @@ TEST_F(POSTTest, BasicPostRequest) {
 // 2. チャンク転送エンコーディングのテスト
 TEST_F(POSTTest, ChunkedTransferEncoding) {
   // 設定
-  Directive rootDirective = createTestDirective("localhost:8080", "./test_tmp/webroot", "1M");
+  Directive rootDirective =
+      createTestDirective("localhost:8080", "./test_tmp/webroot", "1M");
   std::string originalBody = "This is a chunked test message";
   std::string chunkedBody = createChunkedBody(originalBody);
-  
-  HTTPRequest request = createPostRequest("/uploads/chunked.txt", chunkedBody, "text/plain", true);
+
+  HTTPRequest request = createPostRequest("/uploads/chunked.txt", chunkedBody,
+                                          "text/plain", true);
   HTTPResponse response;
-  
+
   // テスト対象の実行
   POST postHandler(rootDirective, request);
   postHandler.handleRequest(response);
-  
+
   // 検証
   EXPECT_EQ(response.getHttpStatusCode(), 201);
   EXPECT_TRUE(fileExists("./test_tmp/webroot/uploads/chunked.txt"));
@@ -172,115 +175,126 @@ TEST_F(POSTTest, ChunkedTransferEncoding) {
 // 3. 大きすぎるリクエストボディのテスト
 TEST_F(POSTTest, BodySizeTooLarge) {
   // 設定
-  Directive rootDirective = createTestDirective("localhost:8080", "./test_tmp/webroot", "10");
-  std::string largeBody(100, 'X'); // 制限より大きいサイズ
+  Directive rootDirective =
+      createTestDirective("localhost:8080", "./test_tmp/webroot", "10");
+  std::string largeBody(100, 'X');  // 制限より大きいサイズ
   HTTPRequest request = createPostRequest("/uploads/large.txt", largeBody);
   HTTPResponse response;
-  
+
   // テスト対象の実行
   POST postHandler(rootDirective, request);
   postHandler.handleRequest(response);
-  
+
   // 検証
-  EXPECT_EQ(response.getHttpStatusCode(), 413); // Request Entity Too Large
+  EXPECT_EQ(response.getHttpStatusCode(), 413);  // Request Entity Too Large
   EXPECT_FALSE(fileExists("./test_tmp/webroot/uploads/large.txt"));
 }
 
 // 4. 存在しないディレクトリへのPOSTテスト
 TEST_F(POSTTest, NonExistentDirectory) {
   // 設定
-  Directive rootDirective = createTestDirective("localhost:8080", "./test_tmp/webroot", "1M");
-  HTTPRequest request = createPostRequest("/non_existent/file.txt", "Test content");
+  Directive rootDirective =
+      createTestDirective("localhost:8080", "./test_tmp/webroot", "1M");
+  HTTPRequest request =
+      createPostRequest("/non_existent/file.txt", "Test content");
   HTTPResponse response;
-  
+
   // テスト対象の実行
   POST postHandler(rootDirective, request);
   postHandler.handleRequest(response);
-  
+
   // 検証
-  EXPECT_EQ(response.getHttpStatusCode(), 404); // Not Found
+  EXPECT_EQ(response.getHttpStatusCode(), 404);  // Not Found
 }
 
 // 5. 権限のないディレクトリへのPOSTテスト
 TEST_F(POSTTest, NoPermissionDirectory) {
   // 設定
-  Directive rootDirective = createTestDirective("localhost:8080", "./test_tmp/webroot", "1M");
-  HTTPRequest request = createPostRequest("/no_permission/file.txt", "Test content");
+  Directive rootDirective =
+      createTestDirective("localhost:8080", "./test_tmp/webroot", "1M");
+  HTTPRequest request =
+      createPostRequest("/no_permission/file.txt", "Test content");
   HTTPResponse response;
-  
+
   // テスト対象の実行
   POST postHandler(rootDirective, request);
   postHandler.handleRequest(response);
-  
+
   // 検証
-  EXPECT_EQ(response.getHttpStatusCode(), 403); // Forbidden
+  EXPECT_EQ(response.getHttpStatusCode(), 403);  // Forbidden
 }
 
 // 6. POSTメソッドが許可されていないパスへのPOSTテスト
 TEST_F(POSTTest, MethodNotAllowed) {
   // POSTが許可されていないディレクティブを作成
-  Directive rootDirective = createTestDirective("localhost:8080", "./test_tmp/webroot", "1M", false);
-  HTTPRequest request = createPostRequest("/uploads/not_allowed.txt", "Test content");
+  Directive rootDirective =
+      createTestDirective("localhost:8080", "./test_tmp/webroot", "1M", false);
+  HTTPRequest request =
+      createPostRequest("/uploads/not_allowed.txt", "Test content");
   HTTPResponse response;
-  
+
   // テスト対象の実行
   POST postHandler(rootDirective, request);
   postHandler.handleRequest(response);
-  
+
   // 検証
-  EXPECT_EQ(response.getHttpStatusCode(), 405); // Method Not Allowed
+  EXPECT_EQ(response.getHttpStatusCode(), 405);  // Method Not Allowed
 }
 
 // 7. 不正なメソッドのテスト
 TEST_F(POSTTest, InvalidMethod) {
   // 設定
-  Directive rootDirective = createTestDirective("localhost:8080", "./test_tmp/webroot", "1M");
+  Directive rootDirective =
+      createTestDirective("localhost:8080", "./test_tmp/webroot", "1M");
   // POSTハンドラにGETメソッドのリクエストを渡す
   std::map<std::string, std::string> headers;
   headers["Host"] = "localhost:8080";
   HTTPRequest request("GET", "/uploads/file.txt", "HTTP/1.1", headers, "");
   HTTPResponse response;
-  
+
   // テスト対象の実行
   POST postHandler(rootDirective, request);
   postHandler.handleRequest(response);
-  
+
   // 検証
-  EXPECT_EQ(response.getHttpStatusCode(), 405); // Method Not Allowed
+  EXPECT_EQ(response.getHttpStatusCode(), 405);  // Method Not Allowed
 }
 
 // 8. CGIスクリプトへのPOSTテスト
 TEST_F(POSTTest, PostToCgiScript) {
   // 設定
-  Directive rootDirective = createTestDirective("localhost:8080", "./test_tmp/webroot", "1M");
-  HTTPRequest request = createPostRequest("/test.py", "name=John&age=30", "application/x-www-form-urlencoded");
+  Directive rootDirective =
+      createTestDirective("localhost:8080", "./test_tmp/webroot", "1M");
+  HTTPRequest request = createPostRequest("/test.py", "name=John&age=30",
+                                          "application/x-www-form-urlencoded");
   HTTPResponse response;
-  
+
   // テスト対象の実行
   POST postHandler(rootDirective, request);
   postHandler.handleRequest(response);
-  
+
   // 検証 - 実際のCGI実行結果は環境に依存するため、ステータスコードのみ検証
   // CGI実行が成功したかどうかは実際の環境に依存しますが、
   // ハンドラーが適切に呼び出されていることを確認します
-  EXPECT_TRUE(response.getHttpStatusCode() == 200 || 
+  EXPECT_TRUE(response.getHttpStatusCode() == 200 ||
               response.getHttpStatusCode() == 500);
 }
 
 // 9. サイズ制限が指定されていない場合のデフォルト制限のテスト
 TEST_F(POSTTest, DefaultSizeLimit) {
   // 設定 - client_max_body_sizeを指定しない
-  Directive rootDirective = createTestDirective("localhost:8080", "./test_tmp/webroot", "");
-  
+  Directive rootDirective =
+      createTestDirective("localhost:8080", "./test_tmp/webroot", "");
+
   // デフォルト制限（1MB）より小さいボディ
-  std::string smallBody(1024, 'X'); // 1KB
+  std::string smallBody(1024, 'X');  // 1KB
   HTTPRequest request = createPostRequest("/uploads/small.txt", smallBody);
   HTTPResponse response;
-  
+
   // テスト対象の実行
   POST postHandler(rootDirective, request);
   postHandler.handleRequest(response);
-  
+
   // 検証
   EXPECT_EQ(response.getHttpStatusCode(), 201);
   EXPECT_TRUE(fileExists("./test_tmp/webroot/uploads/small.txt"));
@@ -289,14 +303,15 @@ TEST_F(POSTTest, DefaultSizeLimit) {
 // 10. 空のボディのPOSTテスト
 TEST_F(POSTTest, EmptyBody) {
   // 設定
-  Directive rootDirective = createTestDirective("localhost:8080", "./test_tmp/webroot", "1M");
+  Directive rootDirective =
+      createTestDirective("localhost:8080", "./test_tmp/webroot", "1M");
   HTTPRequest request = createPostRequest("/uploads/empty.txt", "");
   HTTPResponse response;
-  
+
   // テスト対象の実行
   POST postHandler(rootDirective, request);
   postHandler.handleRequest(response);
-  
+
   // 検証
   EXPECT_EQ(response.getHttpStatusCode(), 201);
   EXPECT_TRUE(fileExists("./test_tmp/webroot/uploads/empty.txt"));
@@ -304,7 +319,7 @@ TEST_F(POSTTest, EmptyBody) {
 }
 
 // メインテスト実行関数
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
#96 

## Summary
This pull request introduces a new `POST` class to handle HTTP POST requests, along with associated test cases to ensure its functionality. The changes include the implementation of various methods to handle file paths, permissions, and request processing, as well as comprehensive tests to validate different scenarios.

### Implementation of `POST` class:

* [`srcs/POST.cpp`](diffhunk://#diff-980c6856c05bb40240e7d9c76ec5ba69247a4250ccf6dbfbb80ed2742895bff4R1-R321): Added a new class `POST` with methods to handle HTTP POST requests, such as `getFullPath`, `fileExists`, `directoryExists`, `hasWritePermission`, `isBodySizeAllowed`, `isPostAllowedForPath`, `processChunkedBody`, `writeToFile`, `setHttpStatusCode`, `handlePostRequest`, and `handleRequest`. These methods ensure the correct handling of file paths, permissions, and request processing.
* [`srcs/POST.hpp`](diffhunk://#diff-dfb624b0621f8056ee20bcdede43bb2342f0674d20a566cb39a2295a4fe170d0R1-R45): Added the header file for the `POST` class, declaring all the methods defined in `POST.cpp`.

### Test cases for `POST` class:

* [`test/srcs/POSTTest.cpp`](diffhunk://#diff-feb2b0b3b602a1879c4924882dc08a365e92484c8eba0604f2d925b577504edcR1-R310): Added test cases to validate the functionality of the `POST` class. The tests cover various scenarios, including basic POST requests, chunked transfer encoding, large request bodies, non-existent directories, permission issues, method restrictions, CGI script handling, default size limits, and empty bodies.
