### PR TITLE
feat: Add the ability to check if an HTTP request method is acceptable

### DIFF
--- a/srcs/GenerateHTTPResponse.hpp
+++ b/srcs/GenerateHTTPResponse.hpp
@@ -21,6 +21,7 @@ class GenerateHTTPResponse : public Handler {
   // utils
   std::string getPathForHttpResponseBody(const int status_code);
   std::string getDirectiveValue(std::string directiveKey);
+  std::vector<std::string> getDirectiveValues(std::string directiveKey);
 
  public:
   GenerateHTTPResponse(Directive rootDirective, HTTPRequest httpRequest);


### PR DESCRIPTION
[ Note ] The `DeleteMethod` class **MUST** check for execution permission within the class.
It is to prevent DELETE from being executed before GenerateHTTPResponse is called.