### PR TITLE
Makefile: add support for LeakSanitizer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ ifeq ($(MAKECMDGOALS), address)
 	FLAGS += -g3 -fsanitize=address
 endif
 
+ifeq ($(MAKECMDGOALS), leaks)
+	FLAGS += -g3 -fsanitize=address -fsanitize=leak
+endif
+
 all: $(NAME)
 
 $(NAME): $(OBJS)
@@ -71,6 +75,11 @@ debug: re
 
 address: re
 
+leaks: re
+	@echo "\033[1;33mRunning with LeakSanitizer...\033[0m"
+	@echo "\033[0;34mNote: Export ASAN_OPTIONS=detect_leaks=1 before running the program\033[0m"
+	@echo "Example: ASAN_OPTIONS=detect_leaks=1 ./$(NAME)"
+
 test:
 	@ make test -C test/
 
@@ -80,4 +89,4 @@ coverage:
 doc:
 	make doc -C docs/ -f doc.mk
 
-.PHONY:	all clean fclean re up run down fmt debug address test coverage doc
+.PHONY:	all clean fclean re up run down fmt debug address test coverage doc leaks


### PR DESCRIPTION
#114 


## Summary
This pull request includes updates to the `Makefile` to add support for LeakSanitizer. The most important changes include adding a new `leaks` target and updating the `.PHONY` list.

New features:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R36-R39): Added `leaks` target to run the program with LeakSanitizer enabled. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R36-R39) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R78-R82)

Updates to existing features:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L83-R92): Updated `.PHONY` list to include the new `leaks` target.
