### PR TITLE
refactor: remove redundant isContain function and streamline HTTP res…

### DIFF
--- a/srcs/DeleteClientMethod.cpp
+++ b/srcs/DeleteClientMethod.cpp
@@ -4,9 +4,6 @@
 
 #include <cstdio>   // std::removeのため
 #include <fstream>  // ファイル存在チェック
-
-#include "GenerateHTTPResponse.hpp"  //  for getDirectiveValues
-
 // 完全なファイルパスを取得する関数
 std::string DeleteClientMethod::getFullPath() const {
   // URLが空の場合は早期リターン
@@ -74,28 +71,7 @@ int DeleteClientMethod::determineStatusCode(const std::string& filePath) const {
   }
 }
 
-static bool isContain(std::vector<std::string> vec, std::string str) {
-  for (std::vector<std::string>::iterator itr = vec.begin(); itr != vec.end();
-       ++itr) {
-    if (*itr == str) {
-      return true;
-    }
-  }
-  return false;
-}
-
 void DeleteClientMethod::handleRequest(HTTPResponse& httpResponse) {
-  GenerateHTTPResponse generateHTTPResponse(_rootDirective, _httpRequest);
-
-  if (isContain(generateHTTPResponse.getDirectiveValues("deny"),
-                _httpRequest.getMethod())) {
-    httpResponse.setHttpStatusCode(405);
-    if (_nextHandler != NULL) {
-      _nextHandler->handleRequest(httpResponse);
-    }
-    return;
-  }
-
   // URLが空かどうかを明示的にチェック
   if (_httpRequest.getURL().empty()) {
     httpResponse.setHttpStatusCode(404);  // Not Found

--- a/srcs/GenerateHTTPResponse.cpp
+++ b/srcs/GenerateHTTPResponse.cpp
@@ -192,17 +192,6 @@ std::string GenerateHTTPResponse::generateHttpResponseBody(
   return httpResponseBody;
 }
 
-// std::vector<std::string>の要素に"指定のメソッド"が含まれているか
-static bool isContain(std::vector<std::string> vec, std::string str) {
-  for (std::vector<std::string>::iterator itr = vec.begin(); itr != vec.end();
-       ++itr) {
-    if (*itr == str) {
-      return true;
-    }
-  }
-  return false;
-}
-
 GenerateHTTPResponse::GenerateHTTPResponse(Directive rootDirective,
                                            HTTPRequest httpRequest)
     : _rootDirective(rootDirective), _httpRequest(httpRequest) {}
@@ -210,10 +199,6 @@ GenerateHTTPResponse::GenerateHTTPResponse(Directive rootDirective,
 void GenerateHTTPResponse::handleRequest(HTTPResponse& httpResponse) {
   bool pageFound = true;
 
-  // メソッドが許可されていない場合HttpStatusCodeを405に設定する
-  if (isContain(getDirectiveValues("deny"), _httpRequest.getMethod())) {
-    httpResponse.setHttpStatusCode(405);
-  }
   // リダイレクトが指定されている場合HttpStatusCodeを301に設定する
   if (getDirectiveValue("return") != "") {
     httpResponse.setHttpStatusCode(301);

--- a/srcs/RunServer.cpp
+++ b/srcs/RunServer.cpp
@@ -125,9 +125,9 @@ void RunServer::handle_client_data(size_t client_fd, std::string receivedPort) {
 
     // URLリダイレクトが指定されている場合，httpRequestのURLをリダイレクト先に変更する
     // URLリダイレクトとはすなわち，HTTPリクエストのURLを変更することであるため．
-    GenerateHTTPResponse serchReturnValue(*rootDirective, httpRequest);
-    if (serchReturnValue.getDirectiveValue("return") != "") {
-      httpRequest.setURL(serchReturnValue.getDirectiveValue("return"));
+    GenerateHTTPResponse search(*rootDirective, httpRequest);
+    if (search.getDirectiveValue("return") != "") {
+      httpRequest.setURL(search.getDirectiveValue("return"));
     }
 
     // 鎖をつなげる
@@ -135,20 +135,26 @@ void RunServer::handle_client_data(size_t client_fd, std::string receivedPort) {
     GenerateHTTPResponse generateHTTPResponse(*rootDirective, httpRequest);
     generateHTTPResponse.setNextHandler(&printResponse);
 
-    // 指定ホストは指定のポートをリッスンするか
     std::string host = httpRequest.getServerName();
     const Directive *hostDirective = rootDirective->findDirective(host);
     std::vector<std::string> hostReveivablePorts =
         hostDirective->getValues("listen");
-    if (isContain(hostReveivablePorts, receivedPort)) {
+    if (!isContain(hostReveivablePorts, receivedPort)) {
+      // 指定ホストは指定のポートをリッスンしない場合
+      httpResponse.setHttpStatusCode(400);  // Bad Request
+      generateHTTPResponse.handleRequest(httpResponse);
+    } else if (isContain(search.getDirectiveValues("deny"),
+                         httpRequest.getMethod())) {
+      // 実行メソッドが許可されていない場合
+      httpResponse.setHttpStatusCode(405);  // Method Not Allowed
+      generateHTTPResponse.handleRequest(httpResponse);
+    } else {
+      // 通常
       Handler *handler = getHTTPMethodHandler(httpRequest.getMethod(),
                                               *rootDirective, httpRequest);
       handler->setNextHandler(&generateHTTPResponse);
       handler->handleRequest(httpResponse);
       delete handler;
-    } else {
-      httpResponse.setHttpStatusCode(400);  // Bad Request
-      generateHTTPResponse.handleRequest(httpResponse);
     }
   } catch (const std::exception &e) {
     std::cerr << "Error handling client data: " << e.what() << std::endl;


### PR DESCRIPTION
This pull request includes several changes to the `DeleteClientMethod`, `GenerateHTTPResponse`, and `RunServer` classes to improve code readability and functionality. The changes involve removing redundant code, renaming variables for clarity, and enhancing request handling.

Codebase simplification and readability improvements:

* Removed the `#include "GenerateHTTPResponse.hpp"` directive from `srcs/DeleteClientMethod.cpp`, as it was no longer needed.
* Deleted the redundant `isContain` function from both `DeleteClientMethod` and `GenerateHTTPResponse` classes, as it was duplicated and no longer necessary. [[1]](diffhunk://#diff-01347865032cdb123810b2d110d943a3e905c3b9adcef2b03d835c182f6c00a7L77-L98) [[2]](diffhunk://#diff-0b379dc00a8fa789bd77f6e531779ce307ab14dd7de07a26fb173ba39050146aL195-L216)
* Renamed the variable `serchReturnValue` to `search` in `RunServer::handle_client_data` for better readability.

Enhancements to request handling:

* Added logic to handle the case where the HTTP method is not allowed, setting the status code to 405 (Method Not Allowed) in `RunServer::handle_client_data`.