### PR TITLE
fix: Allows the GET class to check the existence (404 or not) of dire…

### DIFF
--- a/srcs/GET.cpp
+++ b/srcs/GET.cpp
@@ -12,10 +12,27 @@ static bool endsWith(const std::string& str, const std::string& suffix) {
          str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
 }
 
+// filePathがサーバー上に存在するディレクトリかどうかを調べる
+static bool isDirectory(const std::string& filePath) {
+  struct stat st;
+  if (stat(filePath.c_str(), &st) != 0) {
+    return false;
+  }
+  return S_ISDIR(st.st_mode);
+}
+
 // ファイルが存在するか確認する関数
-static bool fileExists(const std::string& filePath) {
+bool GET::fileExists(const std::string& filePath) {
+  std::string filePathWithIndex = filePath;
+  if (isDirectory(filePath)) {
+    GenerateHTTPResponse searchIndexValue(_rootDirective, _httpRequest);
+    std::string index = searchIndexValue.getDirectiveValue("index");
+    filePathWithIndex +=
+        (filePathWithIndex.end()[-1] == '/') ? index : "/" + index;
+  }
+
   struct stat buffer;
-  return (stat(filePath.c_str(), &buffer) == 0);
+  return (stat(filePathWithIndex.c_str(), &buffer) == 0);
 }
 
 // ファイルが読み取り可能か確認する関数

--- a/srcs/GET.hpp
+++ b/srcs/GET.hpp
@@ -15,6 +15,7 @@ class GET : public Handler {
   // HTTPステータスコードを設定する関数
   void setHttpStatusCode(HTTPResponse& httpResponse,
                          const std::string& fullPath);
+  bool fileExists(const std::string& filePath);
 
  public:
   GET(Directive rootDirective, HTTPRequest httpRequest);


### PR DESCRIPTION
This pull request includes changes to enhance the functionality and structure of the `GET` class in the `srcs/GET.cpp` and `srcs/GET.hpp` files. The most important changes include adding a new function to check if a file path is a directory and modifying the `fileExists` function to handle directory paths correctly.

Enhancements to file handling:

* [`srcs/GET.cpp`](diffhunk://#diff-40434f8febd494a1d150ce92df5824f871ec06783be0f941627cdfda278fbfeeR15-R35): Added a new static function `isDirectory` to check if a given file path is a directory.
* [`srcs/GET.cpp`](diffhunk://#diff-40434f8febd494a1d150ce92df5824f871ec06783be0f941627cdfda278fbfeeR15-R35): Modified the `fileExists` function to use the new `isDirectory` function and append the index file name if the path is a directory.
* [`srcs/GET.hpp`](diffhunk://#diff-c9cf6e930f2fb03d34d775f175aff2056c33e849a43cda2133159357f5ca4eadR18): Updated the `GET` class to include the `fileExists` function as a public member.