### PR TITLE
fix: read the result of cgi when the http status code is `2xx`

### DIFF
--- a/srcs/GenerateHTTPResponse.cpp
+++ b/srcs/GenerateHTTPResponse.cpp
@@ -168,9 +168,10 @@ std::string GenerateHTTPResponse::generateHttpResponseBody(
 
   std::string httpResponseBody;
 
-  // HTTPレスポンスがCGIの実行結果であるか
-  if (endsWith(_httpRequest.getURL(), ".py") ||
-      endsWith(_httpRequest.getURL(), ".sh")) {
+  std::cout << "status_code: " << status_code << std::endl;
+  // CGIは実行されたか（2xx番でないと実行されていない）
+  if (status_code / 100 == 2 && (endsWith(_httpRequest.getURL(), ".py") ||
+                                 endsWith(_httpRequest.getURL(), ".sh"))) {
     httpResponseBody = readFile(CGI_PAGE);
   }
   // ディレクトリリスニングすべきか


### PR DESCRIPTION
This pull request includes a change to the `GenerateHTTPResponse` class in the `srcs/GenerateHTTPResponse.cpp` file. The change ensures that CGI scripts are only considered executed if the HTTP status code indicates a successful operation (2xx).

Codebase improvement:

* [`srcs/GenerateHTTPResponse.cpp`](diffhunk://#diff-0b379dc00a8fa789bd77f6e531779ce307ab14dd7de07a26fb173ba39050146aL171-R174): Added a check to ensure CGI scripts are only considered executed if the HTTP status code is in the 2xx range. Additionally, a debug statement was added to print the `status_code`.