### PR TITLE
Bug/#132/allows you to read an error page when a file fails to load on success

### DIFF
--- a/srcs/GET.cpp
+++ b/srcs/GET.cpp
@@ -27,6 +27,9 @@ bool GET::fileExists(const std::string& filePath) {
   if (isDirectory(filePath)) {
     GenerateHTTPResponse searchIndexValue(_rootDirective, _httpRequest);
     std::string index = searchIndexValue.getDirectiveValue("index");
+    if (index.empty()) {
+      index = "index.html";
+    }
     filePathWithIndex +=
         (filePathWithIndex.end()[-1] == '/') ? index : "/" + index;
   }

--- a/srcs/GenerateHTTPResponse.hpp
+++ b/srcs/GenerateHTTPResponse.hpp
@@ -19,7 +19,8 @@ class GenerateHTTPResponse : public Handler {
   std::string generateHttpResponseHeader(const std::string& httpResponseBody);
   std::string generateHttpResponseBody(const int status_code, bool& pageFound);
   // utils
-  std::string getPathForHttpResponseBody(const int status_code);
+  std::string getSuccessPathForHttpResponseBody();
+  std::string getErrorPathForHttpResponseBody(const int status_code);
 
  public:
   GenerateHTTPResponse(Directive rootDirective, HTTPRequest httpRequest);


### PR DESCRIPTION
This pull request includes several changes to the `GenerateHTTPResponse` class and related methods to improve error handling and file path retrieval for HTTP responses. The most important changes include adding default index handling, renaming methods for clarity, and improving error page retrieval logic.

Improvements to error handling and file path retrieval:

* [`srcs/GET.cpp`](diffhunk://#diff-40434f8febd494a1d150ce92df5824f871ec06783be0f941627cdfda278fbfeeR30-R32): Added a default index value of "index.html" if the `index` directive is empty.

Method renaming for clarity:

* [`srcs/GenerateHTTPResponse.cpp`](diffhunk://#diff-0b379dc00a8fa789bd77f6e531779ce307ab14dd7de07a26fb173ba39050146aL57-R64): Renamed `getPathForHttpResponseBody` to `getErrorPathForHttpResponseBody` and added comments for better understanding. [[1]](diffhunk://#diff-0b379dc00a8fa789bd77f6e531779ce307ab14dd7de07a26fb173ba39050146aL57-R64) [[2]](diffhunk://#diff-0b379dc00a8fa789bd77f6e531779ce307ab14dd7de07a26fb173ba39050146aL77-R86)
* [`srcs/GenerateHTTPResponse.hpp`](diffhunk://#diff-c84a0a4d0e69565218a98b43f442321360252beec7a88b2ee6e6903cf439bbe1L22-R23): Updated method declarations to reflect the new names and added a new method `getSuccessPathForHttpResponseBody`.

Improved error page retrieval logic:

* [`srcs/GenerateHTTPResponse.cpp`](diffhunk://#diff-0b379dc00a8fa789bd77f6e531779ce307ab14dd7de07a26fb173ba39050146aL77-R86): Modified the logic to check if the custom error page is not empty before returning its path.
* [`srcs/GenerateHTTPResponse.cpp`](diffhunk://#diff-0b379dc00a8fa789bd77f6e531779ce307ab14dd7de07a26fb173ba39050146aL185-R194): Added logic to handle successful status codes and retrieve the corresponding file path.

Debugging and logging:

* [`srcs/GenerateHTTPResponse.cpp`](diffhunk://#diff-0b379dc00a8fa789bd77f6e531779ce307ab14dd7de07a26fb173ba39050146aL171): Removed unnecessary debug print statements.