### PR TITLE
fix: use std::string::size() for buffer length in HTTP request parsing

### DIFF
--- a/srcs/RunServer.cpp
+++ b/srcs/RunServer.cpp
@@ -94,7 +94,7 @@ void RunServer::handle_client_data(size_t client_fd, std::string receivedPort) {
   try {
     // HTTPリクエストをパース
     HTTPRequestParser parser;
-    if (parser.feed(buffer, strlen(buffer))) {
+    if (parser.feed(buffer, std::string(buffer).size())) {
       if (parser.hasError()) {
         throw std::invalid_argument("Failed to parse HTTP request");
       }

--- a/test/srcs/RunServerTest.cpp
+++ b/test/srcs/RunServerTest.cpp
@@ -188,7 +188,7 @@ TEST_F(RunServerTest, HandleClientDataBasic) {
 
   // データを書き込む
   const char* testData = "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
-  ASSERT_GT(write(fds[1], testData, strlen(testData)), 0);
+  ASSERT_GT(write(fds[1], testData, std::string(testData).size()), 0);
 
   // 標準エラー出力をキャプチャ (HTTPリクエストパースエラーなど捕捉)
   testing::internal::CaptureStderr();


### PR DESCRIPTION
Using `strlen()` is forbidden!