### PR TITLE
fix: Listen to the directory only if the specified path is a directory

### DIFF
--- a/srcs/GenerateHTTPResponse.cpp
+++ b/srcs/GenerateHTTPResponse.cpp
@@ -176,7 +176,8 @@ std::string GenerateHTTPResponse::generateHttpResponseBody(
   }
   // ディレクトリリスニングすべきか
   else if (getDirectiveValue("autoindex") == "on" &&
-           getDirectiveValue("root") != "" && isDirectory(getDirectiveValue("root") + _httpRequest.getURL())) {
+           getDirectiveValue("root") != "" &&
+           isDirectory(getDirectiveValue("root") + _httpRequest.getURL())) {
     ListenDirectory listenDirectory(getDirectiveValue("root") +
                                     _httpRequest.getURL());
     HTTPResponse response;

--- a/srcs/GenerateHTTPResponse.cpp
+++ b/srcs/GenerateHTTPResponse.cpp
@@ -176,7 +176,7 @@ std::string GenerateHTTPResponse::generateHttpResponseBody(
   }
   // ディレクトリリスニングすべきか
   else if (getDirectiveValue("autoindex") == "on" &&
-           getDirectiveValue("root") != "") {
+           getDirectiveValue("root") != "" && isDirectory(getDirectiveValue("root") + _httpRequest.getURL())) {
     ListenDirectory listenDirectory(getDirectiveValue("root") +
                                     _httpRequest.getURL());
     HTTPResponse response;


### PR DESCRIPTION
Listen to the directory only if the specified path is a directory