### PR TITLE
Bug/#151/replace prohibited functions with available ones

### DIFF
--- a/srcs/CGI.cpp
+++ b/srcs/CGI.cpp
@@ -263,7 +263,7 @@ bool CGI::executeCGI(const std::string& scriptPath) {
     // CGI出力をファイルにリダイレクト
     int fd = open(CGI_PAGE, O_WRONLY | O_CREAT | O_TRUNC, 0644);
     if (fd == -1) {
-      exit(1);
+      std::exit(1);
     }
 
     // 標準出力をファイルにリダイレクト
@@ -338,7 +338,7 @@ bool CGI::executeCGI(const std::string& scriptPath) {
     }
 
     // すべて失敗した場合
-    exit(1);
+    std::exit(1);
   } else {
     // 親プロセス
     cleanupEnv(envp);

--- a/srcs/HTTPRequestParser.cpp
+++ b/srcs/HTTPRequestParser.cpp
@@ -358,7 +358,7 @@ HTTPRequestParser::ParseResult HTTPRequestParser::parse(std::string& buffer) {
             errorMessage = "チャンクサイズがありません";
             return ParsingError;
           }
-          chunkSize = strtol(chunkSizeStr.c_str(), NULL, 16);
+          chunkSize = std::strtol(chunkSizeStr.c_str(), NULL, 16);
           chunkSizeStr.clear();
           state = ChunkSizeNewline;
         } else {
@@ -502,10 +502,10 @@ bool HTTPRequestParser::parseHeader(const std::string& line) {
 std::string HTTPRequestParser::trimString(const std::string& str) const {
   std::string result = str;
   // 先頭の空白を削除
-  while (!result.empty() && isspace(result[0])) result.erase(0, 1);
+  while (!result.empty() && std::isspace(result[0])) result.erase(0, 1);
 
   // 末尾の空白を削除
-  while (!result.empty() && isspace(result[result.length() - 1]))
+  while (!result.empty() && std::isspace(result[result.length() - 1]))
     result.erase(result.length() - 1);
 
   return result;
@@ -556,6 +556,15 @@ void HTTPRequestParser::reset() {
   currentHeaderValue.clear();
 }
 
+int ft_strcasecmp(const char* a, const char* b) {
+  for (;; a++, b++) {
+    int d = std::tolower(*a) - std::tolower(*b);
+    if (d != 0 || !*a) {
+      return d;
+    }
+  }
+}
+
 HTTPRequest HTTPRequestParser::createRequest() const {
   if (!isComplete() || hasError()) {
     return HTTPRequest();
@@ -567,7 +576,7 @@ HTTPRequest HTTPRequestParser::createRequest() const {
   std::map<std::string, std::string>::const_iterator it =
       headers.find("Connection");
   if (it != headers.end()) {
-    if (strcasecmp(it->second.c_str(), "keep-alive") == 0) {
+    if (ft_strcasecmp(it->second.c_str(), "keep-alive") == 0) {
       keepAlive = true;
     }
   } else {

--- a/srcs/ServerData.cpp
+++ b/srcs/ServerData.cpp
@@ -26,27 +26,27 @@ void ServerData::set_server_fd() {
   // ソケットの作成
   if ((server_fd = socket(AF_INET, SOCK_STREAM, 0)) == 0) {
     perror("socket failed");
-    exit(EXIT_FAILURE);
+    std::exit(EXIT_FAILURE);
   }
   // ソケットの再利用を許可する設定を追加
   int opt = 1;
   if (setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0) {
     perror("setsockopt failed");
-    exit(EXIT_FAILURE);
+    std::exit(EXIT_FAILURE);
   }
 }
 
 void ServerData::server_bind() {
   if (bind(server_fd, (struct sockaddr *)&address, sizeof(address)) < 0) {
     perror("bind failed");
-    exit(EXIT_FAILURE);
+    std::exit(EXIT_FAILURE);
   }
 }
 
 void ServerData::server_listen() {
   if (listen(server_fd, MAX_CONNECTION) < 0) {
     perror("listen");
-    exit(EXIT_FAILURE);
+    std::exit(EXIT_FAILURE);
   }
 }
 
@@ -55,7 +55,7 @@ void ServerData::server_accept() {
       accept(server_fd, (struct sockaddr *)&address, (socklen_t *)&addrlen);
   if (new_socket < 0) {
     perror("accept");
-    exit(EXIT_FAILURE);
+    std::exit(EXIT_FAILURE);
   }
 }
 


### PR DESCRIPTION
#151


## Summary
This pull request includes several changes to improve code consistency and readability by using standard library functions and adding a custom string comparison function.

Standard library function usage:

* [`srcs/CGI.cpp`](diffhunk://#diff-ae6b516fa7d5265289aaa13edba98a4359c465f586bc12aa52398370034f1011L266-R266): Replaced `exit(1)` with `std::exit(1)` in the `CGI::executeCGI` method for consistency. [[1]](diffhunk://#diff-ae6b516fa7d5265289aaa13edba98a4359c465f586bc12aa52398370034f1011L266-R266) [[2]](diffhunk://#diff-ae6b516fa7d5265289aaa13edba98a4359c465f586bc12aa52398370034f1011L341-R341)
* [`srcs/HTTPRequestParser.cpp`](diffhunk://#diff-51f4fddcc0a7d23b4b3f86fe8350b72a4c657b2a8a7dbb3b532d95a34a7c5548L361-R361): Replaced `strtol` with `std::strtol` in the `HTTPRequestParser::parse` method to use the standard library function.
* [`srcs/HTTPRequestParser.cpp`](diffhunk://#diff-51f4fddcc0a7d23b4b3f86fe8350b72a4c657b2a8a7dbb3b532d95a34a7c5548L505-R508): Replaced `isspace` with `std::isspace` in the `HTTPRequestParser::trimString` method for better readability and consistency.
* [`srcs/ServerData.cpp`](diffhunk://#diff-2eb0cce667023118a3ed62b2d13eaf790e4387c1adccfa210da9107044ae9176L29-R49): Replaced `exit(EXIT_FAILURE)` with `std::exit(EXIT_FAILURE)` in several methods (`set_server_fd`, `server_bind`, `server_listen`, `server_accept`) for consistency. [[1]](diffhunk://#diff-2eb0cce667023118a3ed62b2d13eaf790e4387c1adccfa210da9107044ae9176L29-R49) [[2]](diffhunk://#diff-2eb0cce667023118a3ed62b2d13eaf790e4387c1adccfa210da9107044ae9176L58-R58)

Custom function addition:

* [`srcs/HTTPRequestParser.cpp`](diffhunk://#diff-51f4fddcc0a7d23b4b3f86fe8350b72a4c657b2a8a7dbb3b532d95a34a7c5548R559-R567): Added a custom case-insensitive string comparison function `ft_strcasecmp` and used it in the `HTTPRequestParser::createRequest` method to replace `strcasecmp`. [[1]](diffhunk://#diff-51f4fddcc0a7d23b4b3f86fe8350b72a4c657b2a8a7dbb3b532d95a34a7c5548R559-R567) [[2]](diffhunk://#diff-51f4fddcc0a7d23b4b3f86fe8350b72a4c657b2a8a7dbb3b532d95a34a7c5548L570-R579)
