### PR TITLE
Bug/#159/process requests exceeding the maximum number of accepted connections in a non blocking manner

### DIFF
--- a/srcs/RunServer.cpp
+++ b/srcs/RunServer.cpp
@@ -32,7 +32,7 @@ void RunServer::add_poll_fd(pollfd poll_fd) { poll_fds.push_back(poll_fd); }
 // 新しい接続を処理する関数
 void RunServer::handle_new_connection(int server_fd, int server_port) {
   int new_socket = accept(server_fd, NULL, NULL);
-  if (new_socket == -1) {
+  if (new_socket == -1 || errno == EAGAIN || errno == EWOULDBLOCK) {
     perror("accept");
     return;
   }

--- a/srcs/ServerData.cpp
+++ b/srcs/ServerData.cpp
@@ -34,6 +34,11 @@ void ServerData::set_server_fd() {
     perror("setsockopt failed");
     std::exit(EXIT_FAILURE);
   }
+  // ソケットを非ブロッキングモードに設定
+  if (fcntl(server_fd, F_SETFL, O_NONBLOCK) < 0) {
+    perror("fcntl failed");
+    std::exit(EXIT_FAILURE);
+  }
 }
 
 void ServerData::server_bind() {

--- a/srcs/ServerData.hpp
+++ b/srcs/ServerData.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <fcntl.h>
 #include <netinet/in.h>
 #include <poll.h>
 #include <sys/socket.h>

--- a/test/srcs/ServerDataTest.cpp
+++ b/test/srcs/ServerDataTest.cpp
@@ -198,14 +198,17 @@ TEST_F(NonBlockingSocketTest, AcceptIsNonBlocking) {
 
     // ノンブロッキングの場合、接続がなければEAGAINまたはEWOULDBLOCKエラーが発生するはず
     // Ubuntu環境では、他のエラーコードが返される可能性もあるため、より一般的な判定に修正
-    EXPECT_EQ(result, -1) << "accept呼び出しが失敗せずに戻りました。接続がないはずなのに接続を受け付けています。";
+    EXPECT_EQ(result, -1) << "accept呼び出しが失敗せずに戻りました。接続がない"
+                             "はずなのに接続を受け付けています。";
 
     // エラー番号が設定されていることを確認
-    EXPECT_TRUE(errno != 0) << "エラーが設定されていません: " << strerror(errno);
+    EXPECT_TRUE(errno != 0)
+        << "エラーが設定されていません: " << strerror(errno);
 
     // 一般的なエラー情報を出力
     if (result == -1) {
-      std::cout << "Accept failed with errno: " << errno << " (" << strerror(errno) << ")" << std::endl;
+      std::cout << "Accept failed with errno: " << errno << " ("
+                << strerror(errno) << ")" << std::endl;
     }
   } catch (const std::exception& e) {
     ADD_FAILURE() << "例外が発生しました: " << e.what();
@@ -261,7 +264,7 @@ TEST_F(NonBlockingSocketTest, NonBlockingErrorHandling) {
     EXPECT_EQ(errno, EBADF);
 
     // 通常のソケットでノンブロッキングaccept
-    errno = 0; // エラーコードをリセット
+    errno = 0;  // エラーコードをリセット
     result = accept(serverData.get_server_fd(), NULL, NULL);
 
     // 接続がなければエラーが返されるはず - Ubuntu互換のために一般化
@@ -270,7 +273,8 @@ TEST_F(NonBlockingSocketTest, NonBlockingErrorHandling) {
 
     // デバッグ情報の出力
     if (result == -1) {
-      std::cout << "Accept on valid socket failed with errno: " << errno << " (" << strerror(errno) << ")" << std::endl;
+      std::cout << "Accept on valid socket failed with errno: " << errno << " ("
+                << strerror(errno) << ")" << std::endl;
     }
   } catch (const std::exception& e) {
     ADD_FAILURE() << "例外が発生しました: " << e.what();


### PR DESCRIPTION
#159 

This pull request introduces non-blocking socket functionality to the `RunServer` and `ServerData` classes, ensuring improved performance and error handling for socket operations. It also adds comprehensive unit tests to validate the new non-blocking behavior across various scenarios.

### Enhancements to socket functionality:
* Modified `RunServer::handle_new_connection` to handle `EAGAIN` and `EWOULDBLOCK` errors during the `accept` call, preventing the function from blocking when no connections are available. (`srcs/RunServer.cpp`)
* Updated `ServerData::set_server_fd` to set the server socket to non-blocking mode using `fcntl`, enabling asynchronous socket operations. (`srcs/ServerData.cpp`)
* Added the necessary `fcntl.h` include to support non-blocking socket configuration. (`srcs/ServerData.hpp`)

### Unit tests for non-blocking behavior:
* Added a new `NonBlockingSocketTest` suite with multiple test cases to verify:
  - Non-blocking mode is correctly applied to server sockets. (`ServerSocketIsNonBlocking`)
  - `accept` behaves as expected in non-blocking mode when no connections are available. (`AcceptIsNonBlocking`)
  - Non-blocking functionality works correctly across multiple ports. (`MultiplePortsNonBlocking`)
  - Proper error handling for invalid socket operations in non-blocking mode. (`NonBlockingErrorHandling`)